### PR TITLE
Add custom prompt instructions for LLM-based metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ASSERT LLM Tools is a Python library for evaluating summaries and RAG (Retrieval-Augmented Generation) outputs using various metrics. The library supports both traditional metrics (ROUGE, BLEU, BERTScore) and LLM-based metrics (faithfulness, hallucination detection, topic preservation).
+
+## Development Commands
+
+### Setup
+```bash
+# Install in editable mode with dev dependencies
+pip install -e ".[dev]"
+
+# Install with all optional dependencies (includes Bedrock and OpenAI)
+pip install -e ".[all]"
+```
+
+### Testing
+```bash
+# Run all tests
+pytest
+
+# Run a specific test file
+pytest test_pii_masking.py
+
+# Run with verbose output
+pytest -v
+```
+
+### Building and Publishing
+```bash
+# Build the package
+python -m build
+
+# Check distribution before upload
+twine check dist/*
+
+# Upload to PyPI
+twine upload dist/*
+```
+
+### Code Quality
+```bash
+# Format code with black
+black assert_llm_tools/
+
+# Sort imports
+isort assert_llm_tools/
+
+# Lint with flake8
+flake8 assert_llm_tools/
+```
+
+## Architecture
+
+### Core Components
+
+**Entry Points** ([core.py](assert_llm_tools/core.py)):
+- `evaluate_summary()`: Main function for summary evaluation
+- `evaluate_rag()`: Main function for RAG evaluation
+- Handles PII masking, metric orchestration, and progress tracking
+
+**LLM Abstraction Layer** ([llm/](assert_llm_tools/llm/)):
+- `LLMConfig`: Unified configuration for all LLM providers
+- `BedrockLLM`: AWS Bedrock integration with proxy support
+- `OpenAILLM`: OpenAI API integration with proxy support
+- All providers implement the same base interface for consistent metric evaluation
+
+**Metric System** ([metrics/](assert_llm_tools/metrics/)):
+- **Base Classes** ([base.py](assert_llm_tools/metrics/base.py)):
+  - `BaseCalculator`: Common LLM initialization and response parsing
+  - `SummaryMetricCalculator`: Summary-specific utilities (topic/claim extraction)
+  - `RAGMetricCalculator`: RAG-specific utilities (context normalization)
+
+- **Summary Metrics** ([metrics/summary/](assert_llm_tools/metrics/summary/)):
+  - Traditional: ROUGE, BLEU, BERTScore, BARTScore
+  - LLM-based: faithfulness, hallucination, topic_preservation, redundancy, conciseness, coherence
+
+- **RAG Metrics** ([metrics/rag/](assert_llm_tools/metrics/rag/)):
+  - All LLM-based: answer_relevance, context_relevance, faithfulness, answer_attribution, completeness
+
+**Utilities** ([utils.py](assert_llm_tools/utils.py)):
+- PII detection and masking using Presidio
+- NLTK initialization (lazy loaded only when BLEU is used)
+- Stopword management
+
+### Key Design Patterns
+
+1. **Lazy Initialization**: NLTK data is only downloaded when BLEU metric is requested to avoid unnecessary dependencies
+2. **Proxy Support**: All LLM providers support proxy configuration via `proxy_url`, `http_proxy`, or `https_proxy`
+3. **Provider Abstraction**: Metrics never directly call provider APIs; they use the LLM abstraction layer
+4. **PII Safety**: Optional PII masking with configurable entity types and masking strategies (full or partial)
+
+### Metric Categories
+
+- **LLM-required summary metrics**: faithfulness, topic_preservation, redundancy, conciseness, coherence, hallucination
+- **Traditional summary metrics**: rouge, bleu, bert_score, bart_score
+- **All RAG metrics require LLM**: answer_relevance, context_relevance, faithfulness, answer_attribution, completeness
+
+## Common Patterns
+
+### Adding a New Summary Metric
+
+1. Create metric file in [assert_llm_tools/metrics/summary/](assert_llm_tools/metrics/summary/)
+2. Implement `calculate_<metric_name>()` function that returns `Dict[str, float]`
+3. For LLM-based metrics, use `SummaryMetricCalculator` base class
+4. Import in [core.py](assert_llm_tools/core.py) and add to `AVAILABLE_SUMMARY_METRICS`
+5. If requires LLM, add to `LLM_REQUIRED_SUMMARY_METRICS`
+
+### Adding a New RAG Metric
+
+1. Create metric file in [assert_llm_tools/metrics/rag/](assert_llm_tools/metrics/rag/)
+2. Implement `calculate_<metric_name>()` function
+3. Use `RAGMetricCalculator` base class
+4. Import in [core.py](assert_llm_tools/core.py) and add to `AVAILABLE_RAG_METRICS`
+
+### Adding a New LLM Provider
+
+1. Create provider file in [assert_llm_tools/llm/](assert_llm_tools/llm/)
+2. Extend `BaseLLM` class
+3. Implement `generate()` method
+4. Add initialization logic in `BaseCalculator.__init__()`
+5. Update [llm/config.py](assert_llm_tools/llm/config.py) validation
+
+## Testing Notes
+
+- Test files (test*.py) in root demonstrate usage patterns
+- PII masking tests are in [test_pii_masking.py](test_pii_masking.py)
+- RAG evaluation tests in [test_rag.py](test_rag.py)
+- Documentation tests in [test_docs.py](test_docs.py)

--- a/assert_llm_tools/llm/bedrock.py
+++ b/assert_llm_tools/llm/bedrock.py
@@ -59,20 +59,20 @@ class BedrockLLM(BaseLLM):
         # Setup proxy configuration for the client
         client_config = None
         proxies = self._get_proxy_config()
-        
+
         if proxies:
             client_config = Config(proxies=proxies)  # Use proxies directly
             # Create a copy of proxies with masked passwords for printing
             masked_proxies = self._mask_proxy_passwords(proxies.copy())
             print(f"Using proxy configuration: {masked_proxies}")
             self._test_proxy_connectivity(proxies)
-        
+
         # Create the client with proxy config if available
-            client_kwargs = {}
-            if client_config:
-                client_kwargs["config"] = client_config  # Use the already created client_config
-                        
-            self.client = session.client("bedrock-runtime", **client_kwargs)
+        client_kwargs = {}
+        if client_config:
+            client_kwargs["config"] = client_config  # Use the already created client_config
+
+        self.client = session.client("bedrock-runtime", **client_kwargs)
 
     def _get_proxy_config(self) -> Dict[str, str]:
         """

--- a/assert_llm_tools/metrics/summary/conciseness.py
+++ b/assert_llm_tools/metrics/summary/conciseness.py
@@ -11,6 +11,17 @@ class ConcisenessCalculator(SummaryMetricCalculator):
     Measures information density and brevity of expression.
     """
 
+    def __init__(self, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None):
+        """
+        Initialize conciseness calculator.
+
+        Args:
+            llm_config: Configuration for LLM
+            custom_instruction: Optional custom instruction to add to the LLM prompt
+        """
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+
     def _get_llm_conciseness_evaluation(self, summary: str) -> float:
         """
         Use LLM to evaluate the conciseness of the summary.
@@ -26,15 +37,17 @@ class ConcisenessCalculator(SummaryMetricCalculator):
         1. Are there unnecessary words or phrases?
         2. Could the same information be expressed more briefly?
         3. Is there any redundant information?
-        
+
         Summary: {summary}
-        
+
         Return a single float score between 0 and 1, where:
         - 1.0 means perfectly concise with no unnecessary words
         - 0.0 means extremely verbose with significant redundancy
-        
-        Just return the number, nothing else.
-        """
+
+        Just return the number, nothing else."""
+
+        if self.custom_instruction:
+            prompt += f"\n\nAdditional Instructions:\n{self.custom_instruction}"
 
         response = self.llm.generate(prompt)
         return self._extract_float_from_response(response)
@@ -90,7 +103,7 @@ class ConcisenessCalculator(SummaryMetricCalculator):
 
 
 def calculate_conciseness_score(
-    source_text: str, summary: str, llm_config: Optional[LLMConfig] = None
+    source_text: str, summary: str, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None
 ) -> float:
     """
     Calculate a conciseness score based on multiple factors:
@@ -102,9 +115,10 @@ def calculate_conciseness_score(
         source_text (str): The original full text
         summary (str): The summary to evaluate
         llm_config (Optional[LLMConfig]): Configuration for LLM-based evaluation
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt for evaluation
 
     Returns:
         float: Conciseness score between 0 and 1, where 1 indicates optimal conciseness
     """
-    calculator = ConcisenessCalculator(llm_config)
+    calculator = ConcisenessCalculator(llm_config, custom_instruction=custom_instruction)
     return calculator.calculate_score(source_text, summary)

--- a/assert_llm_tools/metrics/summary/topic_preservation.py
+++ b/assert_llm_tools/metrics/summary/topic_preservation.py
@@ -10,6 +10,17 @@ class TopicPreservationCalculator(SummaryMetricCalculator):
     Measures how well a summary preserves the main topics from the original text.
     """
 
+    def __init__(self, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None):
+        """
+        Initialize topic preservation calculator.
+
+        Args:
+            llm_config: Configuration for LLM
+            custom_instruction: Optional custom instruction to add to the LLM prompt
+        """
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+
     def _check_topics_in_summary(self, topics: List[str], summary: str) -> List[bool]:
         """
         Check if topics from the original text are present in the summary.
@@ -34,6 +45,9 @@ class TopicPreservationCalculator(SummaryMetricCalculator):
         {topics_str}
 
         Answer with yes/no for each topic:"""
+
+        if self.custom_instruction:
+            prompt += f"\n\nAdditional Instructions:\n{self.custom_instruction}"
 
         response = self.llm.generate(prompt, max_tokens=500)
         results = [
@@ -84,7 +98,7 @@ class TopicPreservationCalculator(SummaryMetricCalculator):
 
 
 def calculate_topic_preservation(
-    reference: str, candidate: str, llm_config: Optional[LLMConfig] = None
+    reference: str, candidate: str, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None
 ) -> Dict[str, any]:
     """
     Evaluate how well a summary preserves the main topics from the original text.
@@ -93,9 +107,10 @@ def calculate_topic_preservation(
         reference (str): The original full text
         candidate (str): The summary to evaluate
         llm_config (Optional[LLMConfig]): Configuration for the LLM to use
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt for evaluation
 
     Returns:
         Dict[str, any]: Dictionary containing topic preservation score and analysis
     """
-    calculator = TopicPreservationCalculator(llm_config)
+    calculator = TopicPreservationCalculator(llm_config, custom_instruction=custom_instruction)
     return calculator.calculate_score(reference, candidate)

--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,61 @@ config = LLMConfig(
 )
 ```
 
+### Custom Prompt Instructions for LLM-Based Metrics
+
+For LLM-based metrics (faithfulness, hallucination, topic_preservation, redundancy, conciseness, coherence), you can provide custom instructions to tailor the evaluation to your specific use case:
+
+```python
+# Basic usage with custom instructions
+results = evaluate_summary(
+    full_text=text,
+    summary=summary,
+    metrics=["faithfulness", "coherence", "hallucination"],
+    llm_config=config,
+    custom_prompt_instructions={
+        "faithfulness": "Apply strict scientific standards. Only mark claims as true if explicitly stated.",
+        "coherence": "Focus on whether the text flows naturally for a technical audience.",
+        "hallucination": "Be extremely strict. Flag any claim that adds details not in the original."
+    }
+)
+```
+
+This is particularly useful for:
+- **Domain-specific evaluation**: Apply industry standards (scientific, legal, medical)
+- **Content type adaptation**: Different criteria for technical docs vs. creative writing
+- **Strictness levels**: Control how lenient or strict the evaluation should be
+
+#### Example: Scientific Content
+
+```python
+results = evaluate_summary(
+    full_text=research_paper,
+    summary=paper_summary,
+    metrics=["faithfulness", "hallucination"],
+    llm_config=config,
+    custom_prompt_instructions={
+        "faithfulness": "Apply strict scientific standards. Verify statistical claims and methodology accurately.",
+        "hallucination": "Flag any claims that go beyond what's explicitly stated in the research."
+    }
+)
+```
+
+#### Example: Creative Writing
+
+```python
+results = evaluate_summary(
+    full_text=story,
+    summary=story_summary,
+    metrics=["coherence", "topic_preservation", "conciseness"],
+    llm_config=config,
+    custom_prompt_instructions={
+        "coherence": "Evaluate for creative writing style. Look for natural narrative flow.",
+        "topic_preservation": "Consider emotional atmosphere and sensory details as important topics.",
+        "conciseness": "For creative writing, some descriptive language is valuable. Don't overly penalize evocative phrasing."
+    }
+)
+```
+
 ## License
 
 MIT

--- a/test_custom_instructions.py
+++ b/test_custom_instructions.py
@@ -1,0 +1,107 @@
+"""
+Test script demonstrating custom prompt instructions feature for LLM-based metrics.
+"""
+
+from assert_llm_tools.core import evaluate_summary
+from assert_llm_tools.llm.config import LLMConfig
+
+# Configure LLM
+llm_config = LLMConfig(
+    provider="bedrock",
+    model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+    region="us-east-1",
+)
+
+# Example text and summary
+full_text = """
+The James Webb Space Telescope (JWST) has revolutionized our understanding of the cosmos since its launch in 2021.
+As the largest and most powerful space telescope ever built, it has provided unprecedented views of distant galaxies,
+exoplanets, and cosmic phenomena. The telescope's infrared capabilities allow it to peer through cosmic dust and gas,
+revealing previously hidden details about star formation and galaxy evolution. Scientists have already used JWST data
+to make groundbreaking discoveries, including observations of some of the earliest galaxies formed after the Big Bang
+and detailed atmospheric analysis of potentially habitable exoplanets.
+"""
+
+summary = """
+The James Webb Space Telescope, launched in 2021, is revolutionizing space observation with its powerful infrared
+capabilities, enabling scientists to study early galaxies and exoplanets in unprecedented detail.
+"""
+
+# Example 1: Using default evaluation (no custom instructions)
+print("=" * 80)
+print("Example 1: Default Evaluation")
+print("=" * 80)
+results_default = evaluate_summary(
+    full_text=full_text,
+    summary=summary,
+    metrics=["faithfulness", "coherence", "hallucination"],
+    llm_config=llm_config,
+    show_progress=False
+)
+print("\nDefault Results:")
+for metric, score in results_default.items():
+    if isinstance(score, (int, float)):
+        print(f"  {metric}: {score:.4f}")
+    else:
+        print(f"  {metric}: {score}")
+
+# Example 2: Using custom instructions for specific metrics
+print("\n" + "=" * 80)
+print("Example 2: With Custom Instructions")
+print("=" * 80)
+results_custom = evaluate_summary(
+    full_text=full_text,
+    summary=summary,
+    metrics=["faithfulness", "coherence", "hallucination"],
+    llm_config=llm_config,
+    show_progress=False,
+    custom_prompt_instructions={
+        "faithfulness": "Apply strict scientific standards. Only mark claims as true if they are explicitly stated in the context, not just implied.",
+        "coherence": "Focus on whether the text flows naturally for a technical/scientific audience. Expect precise, formal language.",
+        "hallucination": "Be extremely strict. Flag any claim that adds details not present in the original text, even if plausible."
+    }
+)
+print("\nCustom Instructions Results:")
+for metric, score in results_custom.items():
+    if isinstance(score, (int, float)):
+        print(f"  {metric}: {score:.4f}")
+    else:
+        print(f"  {metric}: {score}")
+
+# Example 3: Different custom instructions for creative writing
+print("\n" + "=" * 80)
+print("Example 3: Creative Writing Context")
+print("=" * 80)
+
+creative_text = """
+The old bookstore on Main Street had a magical quality about it. Every shelf seemed to whisper stories,
+and the smell of aged paper filled the air like perfume. Sarah loved spending her afternoons there,
+getting lost between the stacks, discovering forgotten classics and hidden gems.
+"""
+
+creative_summary = """
+Sarah enjoyed visiting the enchanting old bookstore on Main Street, where she discovered forgotten books among whispered stories and the scent of aged paper.
+"""
+
+results_creative = evaluate_summary(
+    full_text=creative_text,
+    summary=creative_summary,
+    metrics=["coherence", "topic_preservation", "conciseness"],
+    llm_config=llm_config,
+    show_progress=False,
+    custom_prompt_instructions={
+        "coherence": "Evaluate for creative writing style. Look for natural narrative flow and evocative language.",
+        "topic_preservation": "Consider emotional atmosphere and sensory details as important topics, not just facts.",
+        "conciseness": "For creative writing, some descriptive language is valuable. Don't penalize evocative phrasing."
+    }
+)
+print("\nCreative Writing Results:")
+for metric, score in results_creative.items():
+    if isinstance(score, (int, float)):
+        print(f"  {metric}: {score:.4f}")
+    else:
+        print(f"  {metric}: {score}")
+
+print("\n" + "=" * 80)
+print("Done! Custom instructions allow you to tailor evaluation to your specific use case.")
+print("=" * 80)


### PR DESCRIPTION
This commit adds the ability to customize prompts for LLM-based metrics, allowing users to tailor evaluations to their specific use cases.

Features:
- Added custom_prompt_instructions parameter to evaluate_summary()
- Updated all 6 LLM-based metrics to support custom instructions:
  * coherence
  * faithfulness
  * hallucination
  * redundancy
  * topic_preservation
  * conciseness
- Custom instructions are appended to metric prompts when provided

Bug Fixes:
- Fixed BedrockLLM client initialization issue where client was only created when proxy was configured

Documentation:
- Added comprehensive examples to README for custom instructions
- Created CLAUDE.md for Claude Code integration
- Added test_custom_instructions.py with usage examples

Usage:
  results = evaluate_summary( full_text=text, summary=summary, metrics=["faithfulness", "coherence"], llm_config=config, custom_prompt_instructions={ "faithfulness": "Apply strict scientific standards", "coherence": "Focus on narrative flow" } )

🤖 Generated with [Claude Code](https://claude.com/claude-code)