### PR TITLE
feat(END-52): CLI entry point for single note evaluation

### DIFF
--- a/assert_llm_tools/cli.py
+++ b/assert_llm_tools/cli.py
@@ -1,0 +1,431 @@
+"""
+assert_llm_tools.cli
+~~~~~~~~~~~~~~~~~~~~
+
+Command-line entry point for assert_llm_tools.
+
+Usage examples:
+    assert evaluate --framework fca_suitability_v1 --input note.txt
+    assert evaluate --framework fca_suitability_v1 --input note.txt --output report.json
+    assert evaluate --framework path/to/custom.yaml --input note.txt --output out.json
+    assert evaluate --framework fca_suitability_v1 --input note.txt --verbose
+    assert evaluate --framework fca_suitability_v1 --input note.txt --mask-pii
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Optional
+
+# Module-level import so tests can patch `assert_llm_tools.cli.evaluate_note`.
+from .metrics.note.evaluate_note import evaluate_note  # noqa: E402
+
+
+# ── ANSI colour helpers ────────────────────────────────────────────────────────
+
+def _supports_colour() -> bool:
+    """Return True if the terminal likely supports ANSI colour codes."""
+    import os
+    if not hasattr(sys.stdout, "isatty") or not sys.stdout.isatty():
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return True
+
+
+_COLOUR = None  # lazily initialised on first use
+
+
+def _use_colour() -> bool:
+    global _COLOUR
+    if _COLOUR is None:
+        _COLOUR = _supports_colour()
+    return _COLOUR
+
+
+def _bold(text: str) -> str:
+    return f"\033[1m{text}\033[0m" if _use_colour() else text
+
+
+def _red(text: str) -> str:
+    return f"\033[31m{text}\033[0m" if _use_colour() else text
+
+
+def _green(text: str) -> str:
+    return f"\033[32m{text}\033[0m" if _use_colour() else text
+
+
+def _yellow(text: str) -> str:
+    return f"\033[33m{text}\033[0m" if _use_colour() else text
+
+
+def _cyan(text: str) -> str:
+    return f"\033[36m{text}\033[0m" if _use_colour() else text
+
+
+def _dim(text: str) -> str:
+    return f"\033[2m{text}\033[0m" if _use_colour() else text
+
+
+# ── Severity ordering / display ────────────────────────────────────────────────
+
+_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+_SEVERITY_COLOUR = {
+    "critical": _red,
+    "high": _yellow,
+    "medium": _cyan,
+    "low": _dim,
+}
+
+_STATUS_BULLET = {
+    "present": "✓",
+    "partial": "◐",
+    "missing": "●",
+}
+_STATUS_COLOUR = {
+    "present": _green,
+    "partial": _yellow,
+    "missing": _red,
+}
+
+
+# ── Terminal formatter ─────────────────────────────────────────────────────────
+
+def _format_report(report) -> str:
+    """
+    Render a GapReport as a human-readable string for terminal output.
+
+    Layout::
+
+        Framework: FCA Suitability Note Framework (v1.0.0)
+        Overall:   Non-Compliant ❌
+        Score:     0.42  (17/9 elements assessed)
+
+        GAPS:
+          ● [CRITICAL] recommendation_rationale — missing
+            Suggestions: ...
+          ◐ [HIGH] financial_situation — partial (0.6)
+
+        PRESENT:
+          ✓ client_objectives
+          ✓ risk_attitude
+
+        Summary:
+          <LLM-generated summary text>
+    """
+    lines: list[str] = []
+
+    # ── Header ────────────────────────────────────────────────────────────────
+    fw_label = f"{report.framework_id} (v{report.framework_version})"
+    lines.append(_bold(f"Framework: {fw_label}"))
+
+    if report.passed:
+        overall_label = _green("Compliant ✅")
+    else:
+        overall_label = _red("Non-Compliant ❌")
+    lines.append(f"Overall:   {overall_label}")
+
+    score_pct = f"{report.overall_score:.2f}"
+    stats = report.stats
+    lines.append(
+        f"Score:     {_bold(score_pct)}  "
+        f"({stats.present_count} present / {stats.partial_count} partial / "
+        f"{stats.missing_count} missing  |  {stats.total_elements} elements)"
+    )
+
+    if report.pii_masked:
+        lines.append(_dim("  ⚑ PII masking was applied before evaluation"))
+
+    # ── Gaps ──────────────────────────────────────────────────────────────────
+    gap_items = sorted(
+        [it for it in report.items if it.status != "present"],
+        key=lambda it: (_SEVERITY_ORDER.get(it.severity, 99), it.element_id),
+    )
+
+    if gap_items:
+        lines.append("")
+        lines.append(_bold("GAPS:"))
+        for item in gap_items:
+            bullet = _STATUS_COLOUR[item.status](_STATUS_BULLET[item.status])
+            sev_tag = _SEVERITY_COLOUR.get(item.severity, lambda x: x)(
+                f"[{item.severity.upper()}]"
+            )
+            score_tag = f"  (score: {item.score:.2f})" if item.status == "partial" else ""
+            lines.append(f"  {bullet} {sev_tag} {item.element_id} — {item.status}{score_tag}")
+
+            if item.notes:
+                # Wrap notes at ~76 chars for readability
+                _append_wrapped(lines, f"Notes: {item.notes}", indent="      ")
+
+            if not item.required:
+                lines.append(_dim("      (optional element)"))
+    else:
+        lines.append("")
+        lines.append(_green("GAPS: none — all elements present ✅"))
+
+    # ── Present elements (compact) ────────────────────────────────────────────
+    present_items = [it for it in report.items if it.status == "present"]
+    if present_items:
+        lines.append("")
+        lines.append(_bold("PRESENT:"))
+        for item in present_items:
+            lines.append(f"  {_green('✓')} {item.element_id}")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    if report.summary:
+        lines.append("")
+        lines.append(_bold("Summary:"))
+        _append_wrapped(lines, report.summary, indent="  ")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _append_wrapped(lines: list, text: str, indent: str = "  ", width: int = 76) -> None:
+    """Word-wrap *text* at *width* chars and append lines with *indent*."""
+    import textwrap
+    available = width - len(indent)
+    for wrapped_line in textwrap.wrap(text, width=max(available, 20)):
+        lines.append(f"{indent}{wrapped_line}")
+
+
+# ── JSON serialisation ────────────────────────────────────────────────────────
+
+def _report_to_dict(report) -> dict:
+    """Convert a GapReport to a JSON-serialisable dict."""
+    return asdict(report)
+
+
+# ── Sub-command: evaluate ─────────────────────────────────────────────────────
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    """
+    Entry point for `assert evaluate`.
+
+    Returns an integer exit code (0 = pass, 1 = non-compliant, 2 = error).
+    """
+    # ── Read note text ────────────────────────────────────────────────────────
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: input file not found: {input_path}", file=sys.stderr)
+        return 2
+
+    try:
+        note_text = input_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Error reading input file: {exc}", file=sys.stderr)
+        return 2
+
+    if not note_text.strip():
+        print("Error: input file is empty.", file=sys.stderr)
+        return 2
+
+    # ── Build LLM config ─────────────────────────────────────────────────────
+    llm_config = _build_llm_config(args)
+
+    # ── Run evaluation ────────────────────────────────────────────────────────
+    try:
+        print(f"Evaluating note against framework '{args.framework}' …", file=sys.stderr)
+        report = evaluate_note(
+            note_text=note_text,
+            framework=args.framework,
+            llm_config=llm_config,
+            mask_pii=args.mask_pii,
+            verbose=args.verbose,
+        )
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"Framework error: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001
+        print(f"Evaluation failed: {exc}", file=sys.stderr)
+        if args.verbose:
+            import traceback
+            traceback.print_exc()
+        return 2
+
+    # ── Terminal output ───────────────────────────────────────────────────────
+    print(_format_report(report))
+
+    # ── JSON output ───────────────────────────────────────────────────────────
+    if args.output:
+        output_path = Path(args.output)
+        try:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_path, "w", encoding="utf-8") as fh:
+                json.dump(_report_to_dict(report), fh, indent=2)
+            print(f"Report written to: {output_path}", file=sys.stderr)
+        except OSError as exc:
+            print(f"Error writing output file: {exc}", file=sys.stderr)
+            return 2
+
+    # Exit 0 if passed, 1 if non-compliant (useful for CI pipelines)
+    return 0 if report.passed else 1
+
+
+def _build_llm_config(args: argparse.Namespace):
+    """
+    Construct an LLMConfig from CLI args / environment variables.
+
+    Priority: explicit CLI flags > environment variables > defaults.
+    If no provider flags are given, returns None (evaluate_note will use
+    its own default, typically Bedrock/Claude).
+    """
+    provider = getattr(args, "provider", None)
+    if not provider:
+        return None  # use evaluate_note's built-in default
+
+    from .llm.config import LLMConfig
+
+    return LLMConfig(
+        provider=provider,
+        model_id=args.model_id,
+        region=getattr(args, "region", None),
+        api_key=getattr(args, "api_key", None),
+    )
+
+
+# ── Argument parser ───────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="assert",
+        description="assert_llm_tools — LLM-based compliance and quality evaluation.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=_get_version(),
+    )
+
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # ── evaluate ──────────────────────────────────────────────────────────────
+    eval_p = sub.add_parser(
+        "evaluate",
+        help="Evaluate a compliance note against a regulatory framework.",
+        description=(
+            "Evaluate a compliance note against a regulatory framework and "
+            "produce a gap report."
+        ),
+    )
+    eval_p.add_argument(
+        "--framework", "-f",
+        required=True,
+        metavar="FRAMEWORK",
+        help=(
+            "Built-in framework ID (e.g. 'fca_suitability_v1') or path to a "
+            "custom YAML framework file."
+        ),
+    )
+    eval_p.add_argument(
+        "--input", "-i",
+        required=True,
+        metavar="FILE",
+        help="Path to the plain-text compliance note to evaluate.",
+    )
+    eval_p.add_argument(
+        "--output", "-o",
+        metavar="FILE",
+        default=None,
+        help="Optional path for JSON report output (e.g. report.json).",
+    )
+    eval_p.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        default=False,
+        help="Include LLM reasoning notes in the report output.",
+    )
+    eval_p.add_argument(
+        "--mask-pii",
+        action="store_true",
+        default=False,
+        dest="mask_pii",
+        help="Apply PII detection and masking before sending the note to the LLM.",
+    )
+    eval_p.add_argument(
+        "--no-color",
+        action="store_true",
+        default=False,
+        dest="no_color",
+        help="Disable ANSI colour in terminal output.",
+    )
+
+    # LLM provider overrides (optional — if omitted, the library default is used)
+    llm_group = eval_p.add_argument_group(
+        "LLM provider (optional)",
+        description=(
+            "Override the default LLM provider. If omitted, the library "
+            "default (Bedrock/Claude) is used."
+        ),
+    )
+    llm_group.add_argument(
+        "--provider",
+        choices=["bedrock", "openai"],
+        default=None,
+        help="LLM provider to use.",
+    )
+    llm_group.add_argument(
+        "--model-id",
+        dest="model_id",
+        default=None,
+        help="Model ID / name for the chosen provider.",
+    )
+    llm_group.add_argument(
+        "--region",
+        default=None,
+        help="AWS region (Bedrock only).",
+    )
+    llm_group.add_argument(
+        "--api-key",
+        dest="api_key",
+        default=None,
+        help="API key (OpenAI only).",
+    )
+
+    return parser
+
+
+def _get_version() -> str:
+    """Return the installed package version, falling back gracefully."""
+    try:
+        from importlib.metadata import version
+        return f"assert_llm_tools {version('assert_llm_tools')}"
+    except Exception:
+        return "assert_llm_tools (version unknown)"
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+
+def main(argv: Optional[list] = None) -> None:
+    """
+    Primary entry point wired up via pyproject.toml [project.scripts].
+
+    Parses arguments, dispatches to the appropriate sub-command handler,
+    and exits with a meaningful return code.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Apply --no-color before any rendering
+    if getattr(args, "no_color", False):
+        global _COLOUR
+        _COLOUR = False
+
+    if args.command == "evaluate":
+        exit_code = _cmd_evaluate(args)
+    else:
+        parser.print_help()
+        exit_code = 2
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,18 @@ all = [
 "Homepage" = "https://github.com/charliedouglas/assert"
 "Bug Tracker" = "https://github.com/charliedouglas/assert/issues"
 
+[project.scripts]
+assert = "assert_llm_tools.cli:main"
+
 [tool.setuptools]
 packages = [
     "assert_llm_tools",
     "assert_llm_tools.metrics",
     "assert_llm_tools.metrics.summary",
-    "assert_llm_tools.llm"
+    "assert_llm_tools.metrics.note",
+    "assert_llm_tools.llm",
+    "assert_llm_tools.frameworks",
 ]
+
+[tool.setuptools.package-data]
+"assert_llm_tools.frameworks" = ["*.yaml"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,404 @@
+"""
+Tests for assert_llm_tools.cli
+
+Covers:
+- Argument parsing (happy path and error cases)
+- Terminal formatter output structure
+- JSON serialisation helper
+- _cmd_evaluate error paths (no LLM calls made)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal GapReport / GapItem stubs so tests don't need a live LLM
+# ---------------------------------------------------------------------------
+from assert_llm_tools.metrics.note.models import (
+    GapItem,
+    GapReport,
+    GapReportStats,
+)
+
+
+def _make_stats(**overrides) -> GapReportStats:
+    defaults = dict(
+        total_elements=3,
+        required_elements=2,
+        present_count=1,
+        partial_count=1,
+        missing_count=1,
+        critical_gaps=1,
+        high_gaps=0,
+        medium_gaps=0,
+        low_gaps=0,
+        required_missing_count=1,
+    )
+    defaults.update(overrides)
+    return GapReportStats(**defaults)
+
+
+def _make_report(passed: bool = False) -> GapReport:
+    items = [
+        GapItem(
+            element_id="client_objectives",
+            status="present",
+            score=0.95,
+            evidence="Client wants retirement income",
+            severity="critical",
+            required=True,
+            notes=None,
+        ),
+        GapItem(
+            element_id="risk_attitude",
+            status="partial",
+            score=0.55,
+            evidence="Risk discussed briefly",
+            severity="high",
+            required=True,
+            notes="Risk category not named explicitly",
+        ),
+        GapItem(
+            element_id="recommendation_rationale",
+            status="missing",
+            score=0.0,
+            evidence="",
+            severity="critical",
+            required=True,
+            notes=None,
+        ),
+    ]
+    return GapReport(
+        framework_id="fca_suitability_v1",
+        framework_version="1.0.0",
+        passed=passed,
+        overall_score=0.42,
+        items=items,
+        summary="Two elements are absent or partial.",
+        stats=_make_stats(),
+        pii_masked=False,
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Arg-parsing tests
+# ---------------------------------------------------------------------------
+
+class TestArgParsing:
+    """Test that the argument parser correctly handles inputs."""
+
+    def _parse(self, argv):
+        from assert_llm_tools.cli import _build_parser
+        return _build_parser().parse_args(argv)
+
+    def test_evaluate_required_args(self):
+        args = self._parse(["evaluate", "--framework", "fca_suitability_v1", "--input", "note.txt"])
+        assert args.command == "evaluate"
+        assert args.framework == "fca_suitability_v1"
+        assert args.input == "note.txt"
+        assert args.output is None
+        assert args.verbose is False
+        assert args.mask_pii is False
+
+    def test_evaluate_with_output(self):
+        args = self._parse([
+            "evaluate", "--framework", "fca_suitability_v1",
+            "--input", "note.txt", "--output", "report.json",
+        ])
+        assert args.output == "report.json"
+
+    def test_evaluate_verbose_flag(self):
+        args = self._parse([
+            "evaluate", "-f", "fca_suitability_v1", "-i", "note.txt", "-v",
+        ])
+        assert args.verbose is True
+
+    def test_evaluate_mask_pii_flag(self):
+        args = self._parse([
+            "evaluate", "--framework", "fca_suitability_v1",
+            "--input", "note.txt", "--mask-pii",
+        ])
+        assert args.mask_pii is True
+
+    def test_evaluate_no_color_flag(self):
+        args = self._parse([
+            "evaluate", "--framework", "fca_suitability_v1",
+            "--input", "note.txt", "--no-color",
+        ])
+        assert args.no_color is True
+
+    def test_evaluate_provider_flags(self):
+        args = self._parse([
+            "evaluate", "--framework", "fca_suitability_v1",
+            "--input", "note.txt",
+            "--provider", "openai", "--model-id", "gpt-4o", "--api-key", "sk-test",
+        ])
+        assert args.provider == "openai"
+        assert args.model_id == "gpt-4o"
+        assert args.api_key == "sk-test"
+
+    def test_missing_framework_raises(self):
+        from assert_llm_tools.cli import _build_parser
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args(["evaluate", "--input", "note.txt"])
+
+    def test_missing_input_raises(self):
+        from assert_llm_tools.cli import _build_parser
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args(["evaluate", "--framework", "fca_suitability_v1"])
+
+    def test_no_subcommand_raises(self):
+        from assert_llm_tools.cli import _build_parser
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args([])
+
+
+# ---------------------------------------------------------------------------
+# Terminal formatter tests
+# ---------------------------------------------------------------------------
+
+class TestFormatReport:
+    """Test the human-readable terminal formatter."""
+
+    def setup_method(self):
+        # Force colour OFF for deterministic output
+        import assert_llm_tools.cli as cli_module
+        cli_module._COLOUR = False
+
+    def test_contains_framework_id(self):
+        from assert_llm_tools.cli import _format_report
+        report = _make_report()
+        output = _format_report(report)
+        assert "fca_suitability_v1" in output
+
+    def test_contains_version(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "v1.0.0" in output
+
+    def test_non_compliant_label(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report(passed=False))
+        assert "Non-Compliant" in output
+
+    def test_compliant_label(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report(passed=True))
+        assert "Compliant" in output
+
+    def test_score_shown(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "0.42" in output
+
+    def test_gaps_section(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "GAPS:" in output
+        assert "recommendation_rationale" in output
+
+    def test_present_section(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "PRESENT:" in output
+        assert "client_objectives" in output
+
+    def test_summary_section(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "Summary:" in output
+        assert "Two elements are absent or partial." in output
+
+    def test_missing_bullet_symbol(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "●" in output  # missing bullet
+
+    def test_partial_bullet_symbol(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "◐" in output  # partial bullet
+
+    def test_present_check_symbol(self):
+        from assert_llm_tools.cli import _format_report
+        output = _format_report(_make_report())
+        assert "✓" in output
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation tests
+# ---------------------------------------------------------------------------
+
+class TestReportToDict:
+    def test_round_trip(self):
+        from assert_llm_tools.cli import _report_to_dict
+        report = _make_report()
+        d = _report_to_dict(report)
+        # Should be JSON-serialisable
+        serialised = json.dumps(d)
+        data = json.loads(serialised)
+        assert data["framework_id"] == "fca_suitability_v1"
+        assert data["overall_score"] == pytest.approx(0.42)
+        assert len(data["items"]) == 3
+
+    def test_items_have_expected_keys(self):
+        from assert_llm_tools.cli import _report_to_dict
+        report = _make_report()
+        d = _report_to_dict(report)
+        item = d["items"][0]
+        assert "element_id" in item
+        assert "status" in item
+        assert "score" in item
+        assert "severity" in item
+
+    def test_stats_included(self):
+        from assert_llm_tools.cli import _report_to_dict
+        d = _report_to_dict(_make_report())
+        assert "stats" in d
+        assert d["stats"]["total_elements"] == 3
+
+
+# ---------------------------------------------------------------------------
+# _cmd_evaluate error-path tests (no LLM calls)
+# ---------------------------------------------------------------------------
+
+class TestCmdEvaluateErrors:
+    """Test error handling in _cmd_evaluate without making real LLM calls."""
+
+    def _args(self, **kwargs):
+        defaults = dict(
+            framework="fca_suitability_v1",
+            input="note.txt",
+            output=None,
+            verbose=False,
+            mask_pii=False,
+            provider=None,
+            model_id=None,
+            region=None,
+            api_key=None,
+        )
+        defaults.update(kwargs)
+        return MagicMock(**defaults)
+
+    def test_missing_input_file_returns_2(self, tmp_path):
+        from assert_llm_tools.cli import _cmd_evaluate
+        args = self._args(input=str(tmp_path / "nonexistent.txt"))
+        code = _cmd_evaluate(args)
+        assert code == 2
+
+    def test_empty_input_file_returns_2(self, tmp_path):
+        from assert_llm_tools.cli import _cmd_evaluate
+        note = tmp_path / "note.txt"
+        note.write_text("   \n\n")
+        args = self._args(input=str(note))
+        code = _cmd_evaluate(args)
+        assert code == 2
+
+    def test_unknown_framework_returns_2(self, tmp_path):
+        from assert_llm_tools.cli import _cmd_evaluate
+        note = tmp_path / "note.txt"
+        note.write_text("Some note text.")
+        args = self._args(framework="nonexistent_framework_xyz", input=str(note))
+        code = _cmd_evaluate(args)
+        assert code == 2
+
+    def test_happy_path_non_compliant(self, tmp_path, capsys):
+        """Happy path: mock evaluate_note, assert exit code 1 (non-compliant)."""
+        from assert_llm_tools.cli import _cmd_evaluate
+        import assert_llm_tools.cli as cli_module
+        cli_module._COLOUR = False
+
+        note = tmp_path / "note.txt"
+        note.write_text("Client A wants retirement income. Balanced risk.")
+
+        report = _make_report(passed=False)
+        args = self._args(input=str(note))
+
+        with patch("assert_llm_tools.cli.evaluate_note", return_value=report):
+            code = _cmd_evaluate(args)
+
+        assert code == 1  # non-compliant → exit 1
+        captured = capsys.readouterr()
+        assert "fca_suitability_v1" in captured.out
+        assert "Non-Compliant" in captured.out
+
+    def test_happy_path_compliant(self, tmp_path, capsys):
+        """Happy path: mock evaluate_note, assert exit code 0 (compliant)."""
+        from assert_llm_tools.cli import _cmd_evaluate
+        import assert_llm_tools.cli as cli_module
+        cli_module._COLOUR = False
+
+        note = tmp_path / "note.txt"
+        note.write_text("Excellent note with all elements present.")
+
+        report = _make_report(passed=True)
+        args = self._args(input=str(note))
+
+        with patch("assert_llm_tools.cli.evaluate_note", return_value=report):
+            code = _cmd_evaluate(args)
+
+        assert code == 0  # compliant → exit 0
+
+    def test_json_output_written(self, tmp_path, capsys):
+        """--output flag should write valid JSON to the specified path."""
+        from assert_llm_tools.cli import _cmd_evaluate
+        import assert_llm_tools.cli as cli_module
+        cli_module._COLOUR = False
+
+        note = tmp_path / "note.txt"
+        note.write_text("Some compliance note.")
+        out_file = tmp_path / "report.json"
+
+        report = _make_report(passed=False)
+        args = self._args(input=str(note), output=str(out_file))
+
+        with patch("assert_llm_tools.cli.evaluate_note", return_value=report):
+            _cmd_evaluate(args)
+
+        assert out_file.exists()
+        data = json.loads(out_file.read_text())
+        assert data["framework_id"] == "fca_suitability_v1"
+        assert "items" in data
+        assert "stats" in data
+
+
+# ---------------------------------------------------------------------------
+# main() integration smoke test
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_main_missing_input_exits(self, tmp_path):
+        from assert_llm_tools.cli import main
+        with pytest.raises(SystemExit) as exc_info:
+            main([
+                "evaluate",
+                "--framework", "fca_suitability_v1",
+                "--input", str(tmp_path / "missing.txt"),
+            ])
+        assert exc_info.value.code == 2
+
+    def test_main_happy_path_exits_correctly(self, tmp_path):
+        from assert_llm_tools.cli import main
+        import assert_llm_tools.cli as cli_module
+        cli_module._COLOUR = False
+
+        note = tmp_path / "note.txt"
+        note.write_text("A compliance note.")
+        report = _make_report(passed=True)
+
+        with patch("assert_llm_tools.cli.evaluate_note", return_value=report):
+            with pytest.raises(SystemExit) as exc_info:
+                main([
+                    "evaluate",
+                    "--framework", "fca_suitability_v1",
+                    "--input", str(note),
+                    "--no-color",
+                ])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Implements the `assert evaluate` CLI command (END-52).

## Usage

```bash
# Human-readable terminal output
assert evaluate --framework fca_suitability_v1 --input note.txt

# With JSON output
assert evaluate --framework fca_suitability_v1 --input note.txt --output report.json

# Custom YAML framework
assert evaluate --framework path/to/custom.yaml --input note.txt

# With PII masking and verbose LLM notes
assert evaluate --framework fca_suitability_v1 --input note.txt --mask-pii --verbose
```

## Terminal Output Format

```
Framework: fca_suitability_v1 (v1.0.0)
Overall:   Non-Compliant ❌
Score:     0.42  (3 present / 2 partial / 4 missing  |  9 elements)

GAPS:
  ● [CRITICAL] recommendation_rationale — missing
  ◐ [HIGH] financial_situation — partial  (score: 0.55)
  ● [HIGH] charges_and_costs — missing
  ...

PRESENT:
  ✓ client_objectives
  ✓ risk_attitude
  ...

Summary:
  The evaluation identified 6 gaps across critical and high severity elements...
```

## Changes

- `assert_llm_tools/cli.py` — new CLI module
  - `assert evaluate` subcommand with `--framework`, `--input`, `--output`, `--verbose`, `--mask-pii`, `--no-color`
  - LLM override flags: `--provider`, `--model-id`, `--region`, `--api-key`
  - CI-friendly exit codes: 0 = compliant, 1 = non-compliant, 2 = error
  - ANSI colour output (auto-detected; disabled with `--no-color` or `NO_COLOR` env var)
- `pyproject.toml`
  - `[project.scripts]` entry: `assert = "assert_llm_tools.cli:main"`
  - Added missing packages (`metrics.note`, `frameworks`) and YAML package-data
- `tests/test_cli.py` — 31 tests: arg parsing, formatter, JSON output, error paths, happy path (mocked LLM), `main()` integration

## Test Results

```
31 passed in 2.49s
```

## Depends On

- P1-05 (evaluate_note) — already merged ✅

Closes END-52