### PR TITLE
feat(END-49): wire examples & anti_patterns into LLM evaluation prompts

### DIFF
--- a/assert_llm_tools/metrics/note/evaluate_note.py
+++ b/assert_llm_tools/metrics/note/evaluate_note.py
@@ -195,6 +195,26 @@ class NoteEvaluator(BaseCalculator):
                 f"\nEvaluation guidance:\n{element['guidance'].strip()}\n"
             )
 
+        examples_block = ""
+        if element.get("examples"):
+            examples_lines = "\n".join(
+                f'- "{ex}"' for ex in element["examples"]
+            )
+            examples_block = (
+                f"\nEXAMPLES (phrases that would count as evidence):\n"
+                f"{examples_lines}\n"
+            )
+
+        anti_patterns_block = ""
+        if element.get("anti_patterns"):
+            anti_patterns_lines = "\n".join(
+                f'- "{ap}"' for ap in element["anti_patterns"]
+            )
+            anti_patterns_block = (
+                f"\nANTI-PATTERNS (these do NOT constitute compliant evidence):\n"
+                f"{anti_patterns_lines}\n"
+            )
+
         custom_block = ""
         if self.custom_instruction:
             custom_block = (
@@ -213,6 +233,8 @@ class NoteEvaluator(BaseCalculator):
             f"means there is no meaningful mention whatsoever.\n\n"
             f"Requirement ({required_label}): {element['description'].strip()}"
             f"{guidance_block}"
+            f"{examples_block}"
+            f"{anti_patterns_block}"
             f"{custom_block}\n"
             f"Note text:\n"
             f"---\n"


### PR DESCRIPTION
## Summary

Closes END-49.

Now that `fca_wealth.yaml` (PR #32) provides `examples` and `anti_patterns` per element, the evaluator wires them into the LLM prompt so the model has concrete guidance on what does and doesn't constitute compliant evidence.

## Changes

### `assert_llm_tools/metrics/note/evaluate_note.py`
- `_build_element_prompt()` now appends two optional blocks:
  - **EXAMPLES** (positive, what counts as evidence) — only when `element["examples"]` is a non-empty list
  - **ANTI-PATTERNS** (negative, what does NOT count) — only when `element["anti_patterns"]` is a non-empty list
- Both blocks use the canonical format from the ticket, with items formatted as `- "<string>"`
- Graceful degradation: absent or empty-list fields produce no block at all — prompt is byte-for-byte identical to pre-END-49 for frameworks without those fields (e.g. `fca_suitability_v1`)

### `test_evaluate_note.py`
- New `TestBuildElementPromptExamplesAntiPatterns` class — 15 tests covering:
  - Examples present → correct header and items in prompt
  - Anti-patterns present → correct header and items in prompt
  - Both together → both sections present, examples before anti-patterns
  - Absent fields → sections excluded
  - Empty list → sections excluded
  - Regression guard: prompt unchanged when neither field present
  - All 9 `fca_suitability_v1` elements produce prompts without the new blocks
  - Custom instruction coexists correctly with the new blocks

## Test Results
```
81 passed in 0.21s
```
Zero regressions.