### PR TITLE
test(END-85): Phase 1 unit test suite — evaluation engine, loader, models, PassPolicy

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+"""
+tests/conftest.py
+=================
+
+Shared pytest configuration for the tests/ package.
+
+Native dependencies that are not present in the test environment (boto3,
+botocore, openai) are stubbed out here at the module level *before* any
+assert_llm_tools import can trigger them.  conftest.py is the first thing
+pytest loads, which guarantees the stubs are in sys.modules when any test
+file is collected and imported.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+
+# ── Minimal auto-mock ──────────────────────────────────────────────────────────
+
+class _AutoMock(types.ModuleType):
+    """
+    Module stub where attribute access returns child stubs and calls return
+    stubs.  Just enough to satisfy import-time attribute lookups.
+    """
+
+    def __getattr__(self, name: str) -> "_AutoMock":
+        child = _AutoMock(f"{self.__name__}.{name}")
+        setattr(self, name, child)
+        return child
+
+    def __call__(self, *args, **kwargs) -> "_AutoMock":  # noqa: D105
+        return _AutoMock("_call_result")
+
+
+def _stub_modules() -> None:
+    """Inject stubs for all native deps the library would otherwise import."""
+    for name in (
+        "boto3",
+        "botocore",
+        "botocore.config",
+        "botocore.exceptions",
+        "openai",
+    ):
+        if name not in sys.modules:
+            sys.modules[name] = _AutoMock(name)
+
+    # botocore.config.Config is instantiated directly → must be a real class
+    sys.modules["botocore.config"].Config = type(
+        "Config", (), {"__init__": lambda self, **kw: None}
+    )
+
+    # openai.OpenAI is instantiated directly → must be a real class
+    sys.modules["openai"].OpenAI = type(
+        "OpenAI", (), {"__init__": lambda self, **kw: None}
+    )
+
+
+_stub_modules()
+
+# ── Patch BedrockLLM so NoteEvaluator() never calls boto3 ─────────────────────
+# This must happen after _stub_modules() but before any test module imports
+# NoteEvaluator.
+
+from unittest.mock import MagicMock  # noqa: E402 (after stubs)
+
+import assert_llm_tools.metrics.base as _base_mod  # noqa: E402
+
+_shared_mock_llm = MagicMock(name="shared_conftest_mock_llm")
+_base_mod.BedrockLLM = lambda cfg: _shared_mock_llm  # type: ignore[assignment]

--- a/tests/test_evaluation_engine.py
+++ b/tests/test_evaluation_engine.py
@@ -1,0 +1,885 @@
+"""
+tests/test_evaluation_engine.py
+================================
+
+Comprehensive unit and integration tests for the evaluation engine:
+  - NoteEvaluator.__init__   — defaults, custom args
+  - _parse_element_response  — parsing, edge cases, score correction
+  - _compute_overall_score   — weighting logic
+  - _compute_stats           — aggregate counts
+  - _determine_pass          — (core logic covered more deeply in test_pass_policy.py)
+  - evaluate() / evaluate_note() — full pipeline integration with mocked LLM
+  - custom_instruction        — propagation to prompts
+  - Framework dict input      — pre-loaded dict accepted by evaluate()
+  - Verbose mode              — notes field populated
+  - metadata passthrough
+  - Empty note text
+  - Error paths
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+import assert_llm_tools.metrics.base as _base_mod
+
+from assert_llm_tools.metrics.note.loader import load_framework
+from assert_llm_tools.metrics.note.models import GapItem, GapReport, GapReportStats, PassPolicy
+from assert_llm_tools.metrics.note.evaluate_note import NoteEvaluator, evaluate_note
+
+
+# ── Shared framework / note fixtures ──────────────────────────────────────────
+
+_FRAMEWORK_1_ELEMENT: dict = {
+    "framework_id": "test_single",
+    "name": "Single-Element Test Framework",
+    "version": "0.1",
+    "regulator": "TEST",
+    "elements": [
+        {
+            "id": "elem_a",
+            "description": "Element A description",
+            "required": True,
+            "severity": "critical",
+        }
+    ],
+}
+
+_FRAMEWORK_2_ELEMENTS: dict = {
+    "framework_id": "test_two",
+    "name": "Two-Element Test Framework",
+    "version": "0.1",
+    "regulator": "TEST",
+    "elements": [
+        {
+            "id": "elem_required",
+            "description": "Required critical element",
+            "required": True,
+            "severity": "critical",
+        },
+        {
+            "id": "elem_optional",
+            "description": "Optional high element",
+            "required": False,
+            "severity": "high",
+        },
+    ],
+}
+
+_FRAMEWORK_WITH_GUIDANCE: dict = {
+    "framework_id": "test_guidance",
+    "name": "Framework With Guidance",
+    "version": "0.1",
+    "regulator": "TEST",
+    "elements": [
+        {
+            "id": "risk_profile",
+            "description": "Client risk profile documented",
+            "required": True,
+            "severity": "critical",
+            "guidance": "Look for a named questionnaire, score, and assigned risk category.",
+        }
+    ],
+}
+
+_NOTE_TEXT = "Client objectives: retire at 65. Risk: balanced (score 5/10). CfL: low-medium."
+
+_ELEM_CRITICAL: dict = {
+    "id": "elem_a",
+    "description": "Element A",
+    "required": True,
+    "severity": "critical",
+}
+
+_ELEM_HIGH_OPTIONAL: dict = {
+    "id": "elem_b",
+    "description": "Element B (optional)",
+    "required": False,
+    "severity": "high",
+}
+
+
+def _make_ev(
+    verbose: bool = False,
+    pass_policy: PassPolicy | None = None,
+    custom_instruction: str | None = None,
+) -> NoteEvaluator:
+    """Create a NoteEvaluator with a fresh per-test MagicMock LLM."""
+    ev = NoteEvaluator(
+        verbose=verbose,
+        pass_policy=pass_policy,
+        custom_instruction=custom_instruction,
+    )
+    ev.llm = MagicMock(name="test_mock_llm")
+    return ev
+
+
+# ── FCA 9-element mock responses ──────────────────────────────────────────────
+
+_FCA_ELEMENT_RESPONSES = [
+    "STATUS: present\nSCORE: 0.9\nEVIDENCE: retire at 65\nNOTES: Clear objectives",
+    "STATUS: present\nSCORE: 0.85\nEVIDENCE: balanced score 5/10\nNOTES: Named instrument",
+    "STATUS: present\nSCORE: 0.8\nEVIDENCE: low-medium assessed\nNOTES: CfL distinct",
+    "STATUS: present\nSCORE: 0.75\nEVIDENCE: income and savings\nNOTES: Present",
+    "STATUS: present\nSCORE: 0.7\nEVIDENCE: ISAs for 8 years\nNOTES: Adequate",
+    "STATUS: present\nSCORE: 0.9\nEVIDENCE: matches balanced profile\nNOTES: Linked",
+    "STATUS: present\nSCORE: 0.8\nEVIDENCE: OCF 0.45% adviser 0.5%\nNOTES: Disclosed",
+    "STATUS: present\nSCORE: 0.6\nEVIDENCE: bond fund rejected\nNOTES: Mentioned",
+    "STATUS: present\nSCORE: 0.7\nEVIDENCE: client confirmed receipt\nNOTES: OK",
+]
+_FCA_SUMMARY = "All 9 FCA elements are present and well-documented."
+
+_FCA_FAKE_NOTE = (
+    "Client: Jane Smith. Objective: retirement at 65. "
+    "Risk: balanced (Dynamic Planner 5/10). CfL: absorb losses up to 20%. "
+    "Financial situation: income £60k, savings £50k ISA. "
+    "Knowledge: 8 years ISA experience. "
+    "Recommendation: Global Equity Fund matches balanced profile and 15yr horizon. "
+    "Charges: OCF 0.45%, adviser 0.5% p.a. "
+    "Alternatives: bond fund rejected — insufficient growth. "
+    "Client confirmed receipt of suitability report."
+)
+
+
+def _fca_side_effects() -> list[str]:
+    return list(_FCA_ELEMENT_RESPONSES) + [_FCA_SUMMARY]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# NoteEvaluator.__init__ defaults
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestNoteEvaluatorInit:
+
+    def test_verbose_defaults_to_false(self):
+        ev = _make_ev()
+        assert ev.verbose is False
+
+    def test_verbose_true_set(self):
+        ev = _make_ev(verbose=True)
+        assert ev.verbose is True
+
+    def test_pass_policy_defaults_to_default_pass_policy(self):
+        ev = _make_ev()
+        assert isinstance(ev.pass_policy, PassPolicy)
+        assert ev.pass_policy == PassPolicy()
+
+    def test_custom_pass_policy_stored(self):
+        policy = PassPolicy(block_on_high_missing=False, critical_partial_threshold=0.6)
+        ev = _make_ev(pass_policy=policy)
+        assert ev.pass_policy is policy
+
+    def test_custom_instruction_none_by_default(self):
+        ev = _make_ev()
+        assert ev.custom_instruction is None
+
+    def test_custom_instruction_stored(self):
+        ev = _make_ev(custom_instruction="Use FCA terminology.")
+        assert ev.custom_instruction == "Use FCA terminology."
+
+    def test_is_note_evaluator_subclass(self):
+        from assert_llm_tools.metrics.base import BaseCalculator
+        ev = _make_ev()
+        assert isinstance(ev, BaseCalculator)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _parse_element_response — parsing & score corrections
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestParseElementResponse:
+
+    def test_well_formed_present_response(self):
+        ev = _make_ev()
+        resp = "STATUS: present\nSCORE: 0.85\nEVIDENCE: Client states retirement goal\nNOTES: Clear"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+
+        assert item.element_id == "elem_a"
+        assert item.status == "present"
+        assert item.score == pytest.approx(0.85, abs=1e-3)
+        assert "retirement" in item.evidence
+        assert item.severity == "critical"
+        assert item.required is True
+
+    def test_verbose_false_notes_suppressed(self):
+        ev = _make_ev(verbose=False)
+        resp = "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Strong"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.notes is None
+
+    def test_verbose_true_notes_populated(self):
+        ev = _make_ev(verbose=True)
+        resp = "STATUS: partial\nSCORE: 0.4\nEVIDENCE: Brief mention\nNOTES: Needs more detail"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.notes == "Needs more detail"
+
+    def test_partial_status_parsed(self):
+        ev = _make_ev()
+        resp = "STATUS: partial\nSCORE: 0.4\nEVIDENCE: Some mention\nNOTES: Incomplete"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.status == "partial"
+        assert item.score == pytest.approx(0.4, abs=1e-3)
+
+    def test_missing_status_parsed(self):
+        ev = _make_ev()
+        resp = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.status == "missing"
+        assert item.score == pytest.approx(0.0)
+
+    def test_missing_status_high_score_corrected_to_zero(self):
+        """STATUS=missing with inflated score → score corrected to 0.0."""
+        ev = _make_ev()
+        resp = "STATUS: missing\nSCORE: 0.9\nEVIDENCE: None\nNOTES: LLM inconsistent"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.status == "missing"
+        assert item.score == pytest.approx(0.0, abs=1e-3)
+
+    def test_evidence_none_found_normalised_to_empty(self):
+        ev = _make_ev()
+        resp = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.evidence == ""
+
+    def test_evidence_none_normalised_to_empty(self):
+        ev = _make_ev()
+        resp = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None\nNOTES: Absent"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.evidence == ""
+
+    def test_real_evidence_preserved(self):
+        ev = _make_ev()
+        resp = "STATUS: present\nSCORE: 0.9\nEVIDENCE: Client targets £28k p.a. at 67\nNOTES: Good"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert "£28k" in item.evidence
+
+    def test_missing_score_field_returns_valid_float(self):
+        ev = _make_ev()
+        resp = "STATUS: missing\nEVIDENCE: Nothing\nNOTES: Absent"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert isinstance(item.score, float)
+        assert 0.0 <= item.score <= 1.0
+
+    def test_garbled_response_safe_defaults(self):
+        ev = _make_ev()
+        item = ev._parse_element_response("This response is completely garbled.", _ELEM_CRITICAL)
+        assert item.element_id == "elem_a"
+        assert item.status == "missing"
+        assert isinstance(item.score, float)
+
+    def test_empty_response_safe_defaults(self):
+        ev = _make_ev()
+        item = ev._parse_element_response("", _ELEM_CRITICAL)
+        assert item.element_id == "elem_a"
+        assert item.status == "missing"
+
+    def test_optional_element_properties_propagated(self):
+        ev = _make_ev()
+        resp = "STATUS: present\nSCORE: 0.7\nEVIDENCE: mentioned briefly\nNOTES: OK"
+        item = ev._parse_element_response(resp, _ELEM_HIGH_OPTIONAL)
+        assert item.element_id == "elem_b"
+        assert item.severity == "high"
+        assert item.required is False
+
+    def test_case_insensitive_status_present(self):
+        """STATUS: PRESENT (uppercase) is parsed correctly."""
+        ev = _make_ev()
+        resp = "STATUS: PRESENT\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.status == "present"
+
+    def test_status_partial_score_preserved(self):
+        """STATUS=partial with mid-range score is not corrected."""
+        ev = _make_ev()
+        resp = "STATUS: partial\nSCORE: 0.45\nEVIDENCE: Brief mention\nNOTES: Incomplete"
+        item = ev._parse_element_response(resp, _ELEM_CRITICAL)
+        assert item.status == "partial"
+        assert item.score == pytest.approx(0.45, abs=1e-3)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _compute_overall_score — weighting
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestComputeOverallScore:
+
+    def test_empty_items_returns_zero(self):
+        ev = _make_ev()
+        assert ev._compute_overall_score([]) == pytest.approx(0.0)
+
+    def test_single_required_item_score_returned(self):
+        ev = _make_ev()
+        items = [GapItem("a", "present", 0.75, "", "high", required=True)]
+        assert ev._compute_overall_score(items) == pytest.approx(0.75, abs=1e-4)
+
+    def test_single_optional_item_score_returned(self):
+        ev = _make_ev()
+        items = [GapItem("a", "present", 0.6, "", "low", required=False)]
+        assert ev._compute_overall_score(items) == pytest.approx(0.6, abs=1e-4)
+
+    def test_required_weighted_twice_optional_once(self):
+        """Required 2× weight, optional 1× weight: (0.8×2 + 0.4×1) / 3 = 0.6667."""
+        ev = _make_ev()
+        items = [
+            GapItem("a", "present", 0.8, "", "critical", required=True),
+            GapItem("b", "partial", 0.4, "", "medium", required=False),
+        ]
+        expected = round((0.8 * 2 + 0.4 * 1) / 3.0, 4)
+        assert ev._compute_overall_score(items) == pytest.approx(expected, abs=1e-4)
+
+    def test_all_required_equal_weighting(self):
+        """All required → weighted mean equals simple mean."""
+        ev = _make_ev()
+        items = [
+            GapItem("a", "present", 1.0, "", "critical", required=True),
+            GapItem("b", "missing", 0.0, "", "high", required=True),
+        ]
+        assert ev._compute_overall_score(items) == pytest.approx(0.5, abs=1e-4)
+
+    def test_all_optional_equal_weighting(self):
+        """All optional → same 1× weight each; mean of scores."""
+        ev = _make_ev()
+        items = [
+            GapItem("a", "present", 0.8, "", "medium", required=False),
+            GapItem("b", "present", 0.4, "", "low", required=False),
+        ]
+        assert ev._compute_overall_score(items) == pytest.approx(0.6, abs=1e-4)
+
+    def test_score_rounded_to_4_decimal_places(self):
+        """_compute_overall_score rounds to 4 decimal places."""
+        ev = _make_ev()
+        items = [
+            GapItem("a", "present", 1.0, "", "critical", required=True),
+            GapItem("b", "partial", 0.5, "", "high", required=True),
+            GapItem("c", "missing", 0.0, "", "medium", required=True),
+        ]
+        score = ev._compute_overall_score(items)
+        # Result should be rounded to 4 decimal places
+        assert score == round(score, 4)
+
+    def test_all_present_perfect_score(self):
+        ev = _make_ev()
+        items = [GapItem(f"e{i}", "present", 1.0, "", "critical", required=True) for i in range(5)]
+        assert ev._compute_overall_score(items) == pytest.approx(1.0)
+
+    def test_all_missing_zero_score(self):
+        ev = _make_ev()
+        items = [GapItem(f"e{i}", "missing", 0.0, "", "critical", required=True) for i in range(3)]
+        assert ev._compute_overall_score(items) == pytest.approx(0.0)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _compute_stats — aggregate counts
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestComputeStats:
+
+    def _items(self) -> list[GapItem]:
+        return [
+            GapItem("a", "present", 0.9, "ev", "critical", required=True),
+            GapItem("b", "partial", 0.4, "ev", "high",     required=True),
+            GapItem("c", "missing", 0.0, "",   "medium",   required=False),
+            GapItem("d", "missing", 0.0, "",   "low",      required=True),
+            GapItem("e", "present", 0.8, "ev", "critical", required=False),
+        ]
+
+    def test_total_elements(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        assert stats.total_elements == 5
+
+    def test_required_elements_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        assert stats.required_elements == 3  # a, b, d
+
+    def test_present_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        assert stats.present_count == 2  # a, e
+
+    def test_partial_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        assert stats.partial_count == 1  # b
+
+    def test_missing_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        assert stats.missing_count == 2  # c, d
+
+    def test_critical_gaps_count(self):
+        """Critical gaps = critical elements that are NOT present."""
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        # a=critical+present (no gap), e=critical+present (no gap) → 0
+        assert stats.critical_gaps == 0
+
+    def test_high_gaps_count(self):
+        """High gaps = high elements that are NOT present."""
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        # b=high+partial → 1 gap
+        assert stats.high_gaps == 1
+
+    def test_medium_gaps_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        # c=medium+missing → 1 gap
+        assert stats.medium_gaps == 1
+
+    def test_low_gaps_count(self):
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        # d=low+missing → 1 gap
+        assert stats.low_gaps == 1
+
+    def test_required_missing_count(self):
+        """required_missing_count = required elements that are missing OR partial."""
+        ev = _make_ev()
+        stats = ev._compute_stats(self._items())
+        # b=required+partial, d=required+missing → 2
+        assert stats.required_missing_count == 2
+
+    def test_empty_items_all_zero(self):
+        ev = _make_ev()
+        stats = ev._compute_stats([])
+        assert stats.total_elements == 0
+        assert stats.required_elements == 0
+        assert stats.present_count == 0
+        assert stats.missing_count == 0
+        assert stats.critical_gaps == 0
+
+    def test_all_present_all_required_zero_gaps(self):
+        ev = _make_ev()
+        items = [GapItem(f"e{i}", "present", 1.0, "ev", "critical", required=True) for i in range(3)]
+        stats = ev._compute_stats(items)
+        assert stats.present_count == 3
+        assert stats.missing_count == 0
+        assert stats.critical_gaps == 0
+        assert stats.required_missing_count == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# evaluate() — full pipeline (mocked LLM, 1-element framework)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestEvaluatePipeline:
+
+    def _single_element_responses(self) -> list[str]:
+        return [
+            "STATUS: present\nSCORE: 0.85\nEVIDENCE: Element well documented\nNOTES: Good",
+            "This note covers the element adequately.",
+        ]
+
+    def test_returns_gap_report(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert isinstance(report, GapReport)
+
+    def test_framework_id_correct(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.framework_id == "test_single"
+
+    def test_framework_version_correct(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.framework_version == "0.1"
+
+    def test_items_count_matches_framework(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert len(report.items) == 1
+
+    def test_items_are_gap_item_instances(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        for item in report.items:
+            assert isinstance(item, GapItem)
+
+    def test_stats_is_gap_report_stats(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert isinstance(report.stats, GapReportStats)
+
+    def test_summary_is_non_empty_string(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert isinstance(report.summary, str)
+        assert len(report.summary.strip()) > 0
+
+    def test_passed_true_when_element_present(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.passed is True
+
+    def test_passed_false_when_critical_missing(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = [
+            "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent",
+            "Summary: critical element missing.",
+        ]
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.passed is False
+
+    def test_pii_masked_false_by_default(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT, mask_pii=False)
+        assert report.pii_masked is False
+
+    def test_metadata_empty_dict_by_default(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.metadata == {}
+
+    def test_metadata_preserved(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        meta = {"note_id": "N-42", "adviser": "P. Okonkwo"}
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT, metadata=meta)
+        assert report.metadata["note_id"] == "N-42"
+        assert report.metadata["adviser"] == "P. Okonkwo"
+
+    def test_overall_score_in_range(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert 0.0 <= report.overall_score <= 1.0
+
+    def test_stats_total_matches_items_len(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.stats.total_elements == len(report.items)
+
+    def test_two_element_framework_two_llm_calls_plus_summary(self):
+        """evaluate() makes one LLM call per element + one for summary."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "STATUS: partial\nSCORE: 0.5\nEVIDENCE: Brief\nNOTES: Partial",
+            "Summary of two elements.",
+        ]
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_2_ELEMENTS)
+        assert len(report.items) == 2
+        assert ev.llm.generate.call_count == 3  # 2 elements + 1 summary
+
+    def test_framework_as_preloaded_dict(self):
+        """evaluate() accepts a pre-loaded framework dict directly."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = self._single_element_responses()
+        # Pass the dict directly (not a string ID)
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.framework_id == "test_single"
+
+    def test_invalid_framework_string_raises_file_not_found(self):
+        """Unknown string framework ID → FileNotFoundError from loader."""
+        ev = _make_ev()
+        with pytest.raises(FileNotFoundError):
+            ev.evaluate(_NOTE_TEXT, "absolutely_nonexistent_framework_abc")
+
+    def test_empty_note_text_no_exception(self):
+        """Empty note_text must not raise; results in all-missing items."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = [
+            "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Empty note",
+            "Empty note: all elements missing.",
+        ]
+        report = ev.evaluate("", _FRAMEWORK_1_ELEMENT)
+        assert isinstance(report, GapReport)
+        assert report.items[0].status == "missing"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# custom_instruction propagation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCustomInstructionPropagation:
+
+    def test_custom_instruction_appears_in_llm_prompt(self):
+        """custom_instruction text must appear in the LLM prompt for each element."""
+        custom = "This note follows the FCA Finalised Guidance FG11/5 template."
+        ev = _make_ev(custom_instruction=custom)
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "Summary here.",
+        ]
+        ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+
+        # Check the prompt for the element LLM call contains the custom instruction
+        element_call_args = ev.llm.generate.call_args_list[0]
+        prompt = element_call_args[0][0]  # first positional arg
+        assert custom in prompt, f"custom_instruction not found in prompt: {prompt[:200]}"
+
+    def test_no_custom_instruction_prompt_excludes_additional_instructions(self):
+        """Without custom_instruction, 'Additional instructions' block absent from prompt."""
+        ev = _make_ev(custom_instruction=None)
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "Summary.",
+        ]
+        ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+
+        element_call_args = ev.llm.generate.call_args_list[0]
+        prompt = element_call_args[0][0]
+        assert "Additional instructions" not in prompt
+
+    def test_guidance_appears_in_prompt_when_element_has_guidance(self):
+        """Element guidance text must appear in the LLM prompt."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Named questionnaire\nNOTES: Good",
+            "Summary.",
+        ]
+        ev.evaluate(_NOTE_TEXT, _FRAMEWORK_WITH_GUIDANCE)
+
+        element_call_args = ev.llm.generate.call_args_list[0]
+        prompt = element_call_args[0][0]
+        assert "named questionnaire" in prompt.lower() or "questionnaire" in prompt
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# verbose mode
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestVerboseMode:
+
+    def test_verbose_false_all_notes_none(self):
+        ev = _make_ev(verbose=False)
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Detailed reasoning",
+            "Summary.",
+        ]
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.items[0].notes is None
+
+    def test_verbose_true_notes_populated(self):
+        ev = _make_ev(verbose=True)
+        ev.llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Detailed reasoning",
+            "Summary.",
+        ]
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+        assert report.items[0].notes == "Detailed reasoning"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FCA 9-element framework full integration
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestFCAIntegration:
+
+    def test_fca_returns_9_items(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert len(report.items) == 9
+
+    def test_fca_all_items_are_gap_items(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        for item in report.items:
+            assert isinstance(item, GapItem)
+
+    def test_fca_all_present_passes(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert report.passed is True
+
+    def test_fca_overall_score_float_in_range(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert isinstance(report.overall_score, float)
+        assert 0.0 <= report.overall_score <= 1.0
+
+    def test_fca_framework_id_correct(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert report.framework_id == "fca_suitability_v1"
+
+    def test_fca_stats_total_equals_9(self):
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert report.stats.total_elements == 9
+
+    def test_fca_first_element_is_client_objectives(self):
+        """Element ordering in output must match framework definition order."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert report.items[0].element_id == "client_objectives"
+
+    def test_fca_critical_missing_fails(self):
+        """If client_objectives (critical) is missing → passed=False."""
+        responses = list(_FCA_ELEMENT_RESPONSES)
+        responses[0] = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None\nNOTES: Absent"
+        ev = _make_ev()
+        ev.llm.generate.side_effect = responses + [_FCA_SUMMARY]
+        report = ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert report.passed is False
+
+    def test_fca_llm_called_10_times(self):
+        """9 element calls + 1 summary call = 10 LLM calls for FCA framework."""
+        ev = _make_ev()
+        ev.llm.generate.side_effect = _fca_side_effects()
+        ev.evaluate(_FCA_FAKE_NOTE, "fca_suitability_v1")
+        assert ev.llm.generate.call_count == 10
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# evaluate_note() top-level function
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestEvaluateNoteTopLevel:
+
+    def test_returns_gap_report(self):
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "Summary.",
+        ]
+        with patch.object(_base_mod, "BedrockLLM", return_value=mock_llm):
+            report = evaluate_note(
+                note_text=_NOTE_TEXT,
+                framework=_FRAMEWORK_1_ELEMENT,
+            )
+        assert isinstance(report, GapReport)
+
+    def test_correct_framework_id(self):
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "Summary.",
+        ]
+        with patch.object(_base_mod, "BedrockLLM", return_value=mock_llm):
+            report = evaluate_note(note_text=_NOTE_TEXT, framework=_FRAMEWORK_1_ELEMENT)
+        assert report.framework_id == "test_single"
+
+    def test_top_level_passes_metadata(self):
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = [
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good",
+            "Summary.",
+        ]
+        with patch.object(_base_mod, "BedrockLLM", return_value=mock_llm):
+            report = evaluate_note(
+                note_text=_NOTE_TEXT,
+                framework=_FRAMEWORK_1_ELEMENT,
+                metadata={"batch": "2026-02"},
+            )
+        assert report.metadata["batch"] == "2026-02"
+
+    def test_top_level_passes_pass_policy(self):
+        """evaluate_note() with a custom PassPolicy → policy applied."""
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = [
+            "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None\nNOTES: Absent",
+            "Summary: critical missing.",
+        ]
+        lenient = PassPolicy(block_on_critical_missing=False)
+        with patch.object(_base_mod, "BedrockLLM", return_value=mock_llm):
+            report = evaluate_note(
+                note_text=_NOTE_TEXT,
+                framework=_FRAMEWORK_1_ELEMENT,
+                pass_policy=lenient,
+            )
+        # Lenient policy: critical missing should not block
+        assert report.passed is True
+
+    def test_top_level_fca_9_items(self):
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = _fca_side_effects()
+        with patch.object(_base_mod, "BedrockLLM", return_value=mock_llm):
+            report = evaluate_note(note_text=_FCA_FAKE_NOTE, framework="fca_suitability_v1")
+        assert len(report.items) == 9
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Summary generation failure fallback
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSummaryFallback:
+
+    def test_summary_llm_failure_returns_fallback_string(self):
+        """If summary LLM call raises, a fallback string is used; no exception propagates."""
+        ev = _make_ev()
+        element_resp = "STATUS: present\nSCORE: 0.9\nEVIDENCE: Found\nNOTES: Good"
+
+        def side_effect(prompt, **kwargs):
+            if ev.llm.generate.call_count == 1:
+                return element_resp
+            raise RuntimeError("LLM timeout")
+
+        ev.llm.generate.side_effect = side_effect
+        report = ev.evaluate(_NOTE_TEXT, _FRAMEWORK_1_ELEMENT)
+
+        assert isinstance(report.summary, str)
+        assert len(report.summary.strip()) > 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Structural / import-level checks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStructuralChecks:
+
+    def test_evaluate_note_importable_from_top_level(self):
+        import assert_llm_tools
+        assert callable(assert_llm_tools.evaluate_note)
+
+    def test_gap_report_importable_from_top_level(self):
+        import assert_llm_tools
+        assert assert_llm_tools.GapReport is GapReport
+
+    def test_pass_policy_importable_from_top_level(self):
+        from assert_llm_tools import PassPolicy as TopPolicy
+        assert TopPolicy is PassPolicy
+
+    def test_gap_item_importable_from_top_level(self):
+        from assert_llm_tools import GapItem as TopGapItem
+        assert TopGapItem is GapItem
+
+    def test_note_evaluator_is_base_calculator(self):
+        from assert_llm_tools.metrics.base import BaseCalculator
+        assert issubclass(NoteEvaluator, BaseCalculator)
+
+    def test_detect_and_mask_pii_imported_from_utils(self):
+        """evaluate_note module must use utils.detect_and_mask_pii, not reimplement it."""
+        ev_mod = sys.modules.get("assert_llm_tools.metrics.note.evaluate_note")
+        import assert_llm_tools.utils as utils_mod
+
+        if ev_mod is None or not isinstance(ev_mod, types.ModuleType):
+            pytest.skip("evaluate_note module not yet in sys.modules")
+
+        ev_fn = getattr(ev_mod, "detect_and_mask_pii", None)
+        utils_fn = getattr(utils_mod, "detect_and_mask_pii", None)
+        assert ev_fn is not None, "detect_and_mask_pii not imported into evaluate_note"
+        assert utils_fn is not None, "detect_and_mask_pii not in utils"
+        assert ev_fn is utils_fn, "detect_and_mask_pii reimplemented rather than imported"
+
+    def test_no_direct_llm_instantiation_in_evaluate_note(self):
+        """NoteEvaluator must not directly instantiate BedrockLLM or OpenAILLM."""
+        import inspect
+        import assert_llm_tools.metrics.note.evaluate_note as ev_mod
+        source = inspect.getsource(ev_mod)
+        assert "BedrockLLM(" not in source
+        assert "OpenAILLM(" not in source

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,361 @@
+"""
+tests/test_loader.py
+====================
+
+Unit tests for assert_llm_tools.metrics.note.loader:
+  - load_framework()       — dict passthrough, built-in ID, custom file path,
+                             error handling
+  - _validate_framework()  — required top-level fields, required element fields,
+                             severity validation, edge cases
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from assert_llm_tools.metrics.note.loader import _validate_framework, load_framework
+
+
+# ── Shared fixtures ────────────────────────────────────────────────────────────
+
+_MINIMAL_VALID: dict = {
+    "framework_id": "test_fw",
+    "name": "Test Framework",
+    "version": "1.0.0",
+    "regulator": "TEST",
+    "elements": [
+        {
+            "id": "elem_a",
+            "description": "Element A",
+            "required": True,
+            "severity": "critical",
+        }
+    ],
+}
+
+_ALL_SEVERITY_ELEMENTS: list[dict] = [
+    {"id": "c", "description": "C", "required": True, "severity": "critical"},
+    {"id": "h", "description": "H", "required": True, "severity": "high"},
+    {"id": "m", "description": "M", "required": False, "severity": "medium"},
+    {"id": "l", "description": "L", "required": False, "severity": "low"},
+]
+
+
+def _write_temp_yaml(data: dict) -> str:
+    """Write a framework dict to a temporary YAML file; returns the file path."""
+    fh = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    )
+    yaml.dump(data, fh)
+    fh.close()
+    return fh.name
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# load_framework — dict passthrough
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestLoadFrameworkDict:
+
+    def test_valid_dict_returned_unchanged(self):
+        """load_framework(dict) → same object returned after validation."""
+        fw = load_framework(_MINIMAL_VALID)
+        assert fw is _MINIMAL_VALID
+
+    def test_dict_framework_id_preserved(self):
+        fw = load_framework(_MINIMAL_VALID)
+        assert fw["framework_id"] == "test_fw"
+
+    def test_dict_with_extra_fields_accepted(self):
+        """Extra top-level keys (e.g. description, metadata) must not cause errors."""
+        enriched = {
+            **_MINIMAL_VALID,
+            "description": "Extra field",
+            "effective_date": "2024-01-01",
+            "meeting_type_overrides": {},
+        }
+        fw = load_framework(enriched)
+        assert fw["framework_id"] == "test_fw"
+
+    def test_dict_with_all_severity_levels(self):
+        """Framework with elements of all four severities is valid."""
+        fw_data = {
+            **_MINIMAL_VALID,
+            "elements": _ALL_SEVERITY_ELEMENTS,
+        }
+        fw = load_framework(fw_data)
+        assert len(fw["elements"]) == 4
+
+    def test_dict_with_optional_element_fields_accepted(self):
+        """Elements may have optional fields (guidance, examples, anti_patterns)."""
+        fw_data = {
+            **_MINIMAL_VALID,
+            "elements": [
+                {
+                    "id": "rich",
+                    "description": "Rich element",
+                    "required": True,
+                    "severity": "high",
+                    "guidance": "Look for X",
+                    "examples": ["Example one", "Example two"],
+                    "anti_patterns": ["Bad pattern"],
+                }
+            ],
+        }
+        fw = load_framework(fw_data)
+        assert fw["elements"][0]["id"] == "rich"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# load_framework — built-in IDs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestLoadFrameworkBuiltin:
+
+    def test_fca_suitability_v1_loads(self):
+        """Built-in 'fca_suitability_v1' resolves and loads without error."""
+        fw = load_framework("fca_suitability_v1")
+        assert fw["framework_id"] == "fca_suitability_v1"
+
+    def test_fca_suitability_v1_has_nine_elements(self):
+        fw = load_framework("fca_suitability_v1")
+        assert len(fw["elements"]) == 9
+
+    def test_fca_suitability_v1_required_fields_present(self):
+        """All elements in built-in framework have required fields."""
+        fw = load_framework("fca_suitability_v1")
+        required_fields = {"id", "description", "required", "severity"}
+        for elem in fw["elements"]:
+            missing = required_fields - set(elem.keys())
+            assert not missing, f"Element {elem.get('id')} missing fields: {missing}"
+
+    def test_fca_suitability_v1_known_element_ids(self):
+        """Spot-check known element IDs exist in the FCA framework."""
+        fw = load_framework("fca_suitability_v1")
+        ids = {e["id"] for e in fw["elements"]}
+        for expected_id in (
+            "client_objectives",
+            "risk_attitude",
+            "capacity_for_loss",
+            "financial_situation",
+            "knowledge_and_experience",
+            "recommendation_rationale",
+            "charges_and_costs",
+        ):
+            assert expected_id in ids, f"Expected element '{expected_id}' not found"
+
+    def test_fca_suitability_v1_regulator_is_fca(self):
+        fw = load_framework("fca_suitability_v1")
+        assert "FCA" in fw["regulator"]
+
+    def test_unknown_builtin_id_raises_file_not_found(self):
+        """String that is neither a valid path nor a built-in ID → FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_framework("totally_nonexistent_framework_xyz789")
+
+    def test_unknown_builtin_error_message_mentions_name(self):
+        """FileNotFoundError message should mention the framework ID."""
+        with pytest.raises(FileNotFoundError, match="no_such_fw"):
+            load_framework("no_such_fw")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# load_framework — custom YAML file paths
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestLoadFrameworkCustomPath:
+
+    def test_absolute_yaml_path_loads(self):
+        """Absolute path to a valid YAML file resolves and loads correctly."""
+        path = _write_temp_yaml(_MINIMAL_VALID)
+        try:
+            fw = load_framework(path)
+            assert fw["framework_id"] == "test_fw"
+        finally:
+            os.unlink(path)
+
+    def test_custom_yaml_elements_returned(self):
+        """Elements from a custom YAML are returned intact."""
+        custom = {
+            "framework_id": "custom_fw",
+            "name": "Custom",
+            "version": "2.0",
+            "regulator": "Custom Regulator",
+            "elements": [
+                {"id": "e1", "description": "E1", "required": True, "severity": "high"},
+                {"id": "e2", "description": "E2", "required": False, "severity": "low"},
+            ],
+        }
+        path = _write_temp_yaml(custom)
+        try:
+            fw = load_framework(path)
+            assert fw["framework_id"] == "custom_fw"
+            assert len(fw["elements"]) == 2
+            assert fw["elements"][0]["id"] == "e1"
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_path_raises_file_not_found(self):
+        """String that looks like a path but doesn't exist → FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_framework("/absolutely/does/not/exist/framework.yaml")
+
+    def test_custom_yaml_with_all_optional_element_fields(self):
+        """YAML with guidance/examples/anti_patterns loads without error."""
+        custom = {
+            "framework_id": "rich_fw",
+            "name": "Rich Framework",
+            "version": "1.0",
+            "regulator": "TEST",
+            "elements": [
+                {
+                    "id": "el",
+                    "description": "Element",
+                    "required": True,
+                    "severity": "critical",
+                    "guidance": "Detailed guidance here",
+                    "examples": ["Good example"],
+                    "anti_patterns": ["Bad pattern"],
+                }
+            ],
+        }
+        path = _write_temp_yaml(custom)
+        try:
+            fw = load_framework(path)
+            assert fw["elements"][0]["guidance"] == "Detailed guidance here"
+        finally:
+            os.unlink(path)
+
+    def test_invalid_yaml_content_raises_value_error(self):
+        """YAML file with invalid framework structure → ValueError."""
+        bad_data = {
+            # Missing required top-level fields
+            "name": "Bad Framework",
+            "elements": [],
+        }
+        path = _write_temp_yaml(bad_data)
+        try:
+            with pytest.raises((ValueError, FileNotFoundError)):
+                load_framework(path)
+        finally:
+            os.unlink(path)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _validate_framework — top-level field validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestValidateFrameworkTopLevel:
+
+    def test_valid_framework_no_exception(self):
+        """Fully valid framework passes validation silently."""
+        _validate_framework(_MINIMAL_VALID)  # must not raise
+
+    def test_missing_framework_id_raises_value_error(self):
+        bad = {k: v for k, v in _MINIMAL_VALID.items() if k != "framework_id"}
+        with pytest.raises(ValueError, match="framework_id"):
+            _validate_framework(bad)
+
+    def test_missing_name_raises_value_error(self):
+        bad = {k: v for k, v in _MINIMAL_VALID.items() if k != "name"}
+        with pytest.raises(ValueError, match="name"):
+            _validate_framework(bad)
+
+    def test_missing_version_raises_value_error(self):
+        bad = {k: v for k, v in _MINIMAL_VALID.items() if k != "version"}
+        with pytest.raises(ValueError, match="version"):
+            _validate_framework(bad)
+
+    def test_missing_regulator_raises_value_error(self):
+        bad = {k: v for k, v in _MINIMAL_VALID.items() if k != "regulator"}
+        with pytest.raises(ValueError, match="regulator"):
+            _validate_framework(bad)
+
+    def test_missing_elements_raises_value_error(self):
+        bad = {k: v for k, v in _MINIMAL_VALID.items() if k != "elements"}
+        with pytest.raises(ValueError, match="elements"):
+            _validate_framework(bad)
+
+    def test_empty_elements_list_raises_value_error(self):
+        bad = {**_MINIMAL_VALID, "elements": []}
+        with pytest.raises(ValueError):
+            _validate_framework(bad)
+
+    def test_elements_not_a_list_raises_value_error(self):
+        bad = {**_MINIMAL_VALID, "elements": "not a list"}
+        with pytest.raises(ValueError):
+            _validate_framework(bad)
+
+    def test_empty_framework_dict_raises_value_error(self):
+        with pytest.raises(ValueError):
+            _validate_framework({})
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _validate_framework — per-element field validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestValidateFrameworkElements:
+
+    def _fw_with_elements(self, elements: list) -> dict:
+        return {**_MINIMAL_VALID, "elements": elements}
+
+    def test_element_missing_id_raises_value_error(self):
+        bad_elem = {"description": "No id", "required": True, "severity": "high"}
+        with pytest.raises(ValueError, match="id"):
+            _validate_framework(self._fw_with_elements([bad_elem]))
+
+    def test_element_missing_description_raises_value_error(self):
+        bad_elem = {"id": "x", "required": True, "severity": "high"}
+        with pytest.raises(ValueError, match="description"):
+            _validate_framework(self._fw_with_elements([bad_elem]))
+
+    def test_element_missing_required_flag_raises_value_error(self):
+        bad_elem = {"id": "x", "description": "X", "severity": "high"}
+        with pytest.raises(ValueError, match="required"):
+            _validate_framework(self._fw_with_elements([bad_elem]))
+
+    def test_element_missing_severity_raises_value_error(self):
+        bad_elem = {"id": "x", "description": "X", "required": True}
+        with pytest.raises(ValueError, match="severity"):
+            _validate_framework(self._fw_with_elements([bad_elem]))
+
+    def test_element_invalid_severity_raises_value_error(self):
+        bad_elem = {"id": "x", "description": "X", "required": True, "severity": "urgent"}
+        with pytest.raises(ValueError, match="urgent"):
+            _validate_framework(self._fw_with_elements([bad_elem]))
+
+    def test_all_valid_severities_accepted(self):
+        """All four valid severity values must pass validation."""
+        for sev in ("critical", "high", "medium", "low"):
+            elem = {"id": "x", "description": "X", "required": True, "severity": sev}
+            _validate_framework(self._fw_with_elements([elem]))  # must not raise
+
+    def test_second_invalid_element_raises_value_error(self):
+        """Validation error in second element is detected."""
+        good_elem = {"id": "a", "description": "A", "required": True, "severity": "critical"}
+        bad_elem = {"id": "b", "description": "B", "required": True, "severity": "extreme"}
+        with pytest.raises(ValueError, match="extreme"):
+            _validate_framework(self._fw_with_elements([good_elem, bad_elem]))
+
+    def test_multiple_valid_elements(self):
+        """Framework with 4 elements of different severities passes validation."""
+        _validate_framework(
+            self._fw_with_elements(_ALL_SEVERITY_ELEMENTS)
+        )  # must not raise
+
+    def test_element_with_optional_extra_fields_valid(self):
+        """Extra element fields (guidance, examples) must not cause validation failure."""
+        elem = {
+            "id": "x",
+            "description": "X",
+            "required": False,
+            "severity": "low",
+            "guidance": "Extra guidance",
+            "examples": ["ex1"],
+            "anti_patterns": ["bad1"],
+        }
+        _validate_framework(self._fw_with_elements([elem]))  # must not raise

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,365 @@
+"""
+tests/test_models.py
+====================
+
+Unit tests for assert_llm_tools.metrics.note.models:
+  - GapItem    — field defaults, type checks, construction
+  - GapReport  — field defaults, metadata default, pii_masked default
+  - GapReportStats — all integer fields, construction
+  - PassPolicy — default values, field types, custom values
+
+No LLM calls are made; these are pure data-model tests.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import fields
+
+import pytest
+
+from assert_llm_tools.metrics.note.models import (
+    GapItem,
+    GapReport,
+    GapReportStats,
+    PassPolicy,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def _make_gap_item(**overrides) -> GapItem:
+    defaults = dict(
+        element_id="elem_x",
+        status="present",
+        score=0.8,
+        evidence="some evidence",
+        severity="critical",
+        required=True,
+    )
+    defaults.update(overrides)
+    return GapItem(**defaults)
+
+
+def _make_stats(**overrides) -> GapReportStats:
+    defaults = dict(
+        total_elements=9,
+        required_elements=7,
+        present_count=7,
+        partial_count=1,
+        missing_count=1,
+        critical_gaps=0,
+        high_gaps=1,
+        medium_gaps=0,
+        low_gaps=0,
+        required_missing_count=2,
+    )
+    defaults.update(overrides)
+    return GapReportStats(**defaults)
+
+
+def _make_report(**overrides) -> GapReport:
+    item = _make_gap_item()
+    stats = _make_stats(
+        total_elements=1,
+        required_elements=1,
+        present_count=1,
+        partial_count=0,
+        missing_count=0,
+        critical_gaps=0,
+        high_gaps=0,
+        medium_gaps=0,
+        low_gaps=0,
+        required_missing_count=0,
+    )
+    defaults = dict(
+        framework_id="test_fw",
+        framework_version="1.0.0",
+        passed=True,
+        overall_score=0.8,
+        items=[item],
+        summary="All elements present.",
+        stats=stats,
+    )
+    defaults.update(overrides)
+    return GapReport(**defaults)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GapItem
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestGapItem:
+
+    def test_is_dataclass(self):
+        assert dataclasses.is_dataclass(GapItem)
+
+    def test_construction_all_required_fields(self):
+        item = GapItem(
+            element_id="risk_profile",
+            status="present",
+            score=0.9,
+            evidence="Risk assessed via Dynamic Planner",
+            severity="critical",
+            required=True,
+        )
+        assert item.element_id == "risk_profile"
+        assert item.status == "present"
+        assert item.score == pytest.approx(0.9)
+        assert item.evidence == "Risk assessed via Dynamic Planner"
+        assert item.severity == "critical"
+        assert item.required is True
+
+    def test_notes_defaults_to_none(self):
+        """Optional notes field defaults to None when not supplied."""
+        item = _make_gap_item()
+        assert item.notes is None
+
+    def test_notes_can_be_set(self):
+        item = _make_gap_item(notes="Some LLM reasoning here")
+        assert item.notes == "Some LLM reasoning here"
+
+    def test_required_false(self):
+        item = _make_gap_item(required=False)
+        assert item.required is False
+
+    def test_status_partial(self):
+        item = _make_gap_item(status="partial", score=0.45)
+        assert item.status == "partial"
+        assert item.score == pytest.approx(0.45)
+
+    def test_status_missing_zero_score(self):
+        item = _make_gap_item(status="missing", score=0.0, evidence="")
+        assert item.status == "missing"
+        assert item.score == pytest.approx(0.0)
+        assert item.evidence == ""
+
+    def test_all_severity_values(self):
+        for sev in ("critical", "high", "medium", "low"):
+            item = _make_gap_item(severity=sev)
+            assert item.severity == sev
+
+    def test_score_boundary_zero(self):
+        item = _make_gap_item(score=0.0)
+        assert item.score == pytest.approx(0.0)
+
+    def test_score_boundary_one(self):
+        item = _make_gap_item(score=1.0)
+        assert item.score == pytest.approx(1.0)
+
+    def test_field_names(self):
+        """GapItem must have exactly these fields."""
+        field_names = {f.name for f in fields(GapItem)}
+        expected = {"element_id", "status", "score", "evidence", "severity", "required", "notes"}
+        assert expected == field_names
+
+    def test_equality_same_values(self):
+        """Two GapItems with the same values should be equal (dataclass default)."""
+        a = _make_gap_item(notes=None)
+        b = _make_gap_item(notes=None)
+        assert a == b
+
+    def test_inequality_different_score(self):
+        a = _make_gap_item(score=0.8)
+        b = _make_gap_item(score=0.5)
+        assert a != b
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GapReport
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestGapReport:
+
+    def test_is_dataclass(self):
+        assert dataclasses.is_dataclass(GapReport)
+
+    def test_construction_required_fields(self):
+        report = _make_report()
+        assert report.framework_id == "test_fw"
+        assert report.framework_version == "1.0.0"
+        assert report.passed is True
+        assert isinstance(report.overall_score, float)
+        assert isinstance(report.items, list)
+        assert isinstance(report.summary, str)
+
+    def test_pii_masked_defaults_to_false(self):
+        """pii_masked field default is False."""
+        report = _make_report()
+        assert report.pii_masked is False
+
+    def test_pii_masked_can_be_true(self):
+        report = _make_report(pii_masked=True)
+        assert report.pii_masked is True
+
+    def test_metadata_defaults_to_empty_dict(self):
+        """metadata field default is {} (each instance gets a fresh dict)."""
+        report = _make_report()
+        assert report.metadata == {}
+        assert isinstance(report.metadata, dict)
+
+    def test_metadata_not_shared_between_instances(self):
+        """Default metadata dict must not be shared between instances."""
+        r1 = _make_report()
+        r2 = _make_report()
+        r1.metadata["key"] = "value"
+        assert "key" not in r2.metadata
+
+    def test_metadata_can_hold_arbitrary_values(self):
+        meta = {"note_id": "N-001", "adviser": "Jane Doe", "batch": 42}
+        report = _make_report(metadata=meta)
+        assert report.metadata["note_id"] == "N-001"
+        assert report.metadata["adviser"] == "Jane Doe"
+        assert report.metadata["batch"] == 42
+
+    def test_passed_false(self):
+        report = _make_report(passed=False)
+        assert report.passed is False
+
+    def test_items_list_multiple_elements(self):
+        items = [_make_gap_item(element_id=f"e{i}") for i in range(5)]
+        report = _make_report(items=items)
+        assert len(report.items) == 5
+
+    def test_overall_score_is_float(self):
+        report = _make_report(overall_score=0.73)
+        assert isinstance(report.overall_score, float)
+
+    def test_stats_is_gap_report_stats(self):
+        report = _make_report()
+        assert isinstance(report.stats, GapReportStats)
+
+    def test_field_names(self):
+        field_names = {f.name for f in fields(GapReport)}
+        expected = {
+            "framework_id", "framework_version", "passed", "overall_score",
+            "items", "summary", "stats", "pii_masked", "metadata",
+        }
+        assert expected == field_names
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GapReportStats
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestGapReportStats:
+
+    def test_is_dataclass(self):
+        assert dataclasses.is_dataclass(GapReportStats)
+
+    def test_construction(self):
+        stats = _make_stats()
+        assert stats.total_elements == 9
+        assert stats.required_elements == 7
+        assert stats.present_count == 7
+        assert stats.partial_count == 1
+        assert stats.missing_count == 1
+        assert stats.critical_gaps == 0
+        assert stats.high_gaps == 1
+        assert stats.medium_gaps == 0
+        assert stats.low_gaps == 0
+        assert stats.required_missing_count == 2
+
+    def test_all_fields_are_int(self):
+        """All fields on GapReportStats must be integers."""
+        stats = _make_stats()
+        for f in fields(GapReportStats):
+            value = getattr(stats, f.name)
+            assert isinstance(value, int), f"{f.name} should be int, got {type(value)}"
+
+    def test_zero_stats(self):
+        """All-zero stats are valid (empty framework edge case)."""
+        stats = _make_stats(
+            total_elements=0,
+            required_elements=0,
+            present_count=0,
+            partial_count=0,
+            missing_count=0,
+            critical_gaps=0,
+            high_gaps=0,
+            medium_gaps=0,
+            low_gaps=0,
+            required_missing_count=0,
+        )
+        assert stats.total_elements == 0
+
+    def test_field_names(self):
+        field_names = {f.name for f in fields(GapReportStats)}
+        expected = {
+            "total_elements", "required_elements", "present_count", "partial_count",
+            "missing_count", "critical_gaps", "high_gaps", "medium_gaps", "low_gaps",
+            "required_missing_count",
+        }
+        assert expected == field_names
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PassPolicy
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPassPolicyModel:
+
+    def test_is_dataclass(self):
+        assert dataclasses.is_dataclass(PassPolicy)
+
+    def test_default_values(self):
+        p = PassPolicy()
+        assert p.block_on_critical_missing is True
+        assert p.block_on_critical_partial is True
+        assert p.block_on_high_missing is True
+        assert p.critical_partial_threshold == pytest.approx(0.5)
+
+    def test_all_bool_fields_are_bool(self):
+        p = PassPolicy()
+        assert isinstance(p.block_on_critical_missing, bool)
+        assert isinstance(p.block_on_critical_partial, bool)
+        assert isinstance(p.block_on_high_missing, bool)
+
+    def test_threshold_is_float(self):
+        p = PassPolicy()
+        assert isinstance(p.critical_partial_threshold, float)
+
+    def test_custom_lenient_policy(self):
+        p = PassPolicy(
+            block_on_critical_missing=False,
+            block_on_critical_partial=False,
+            block_on_high_missing=False,
+            critical_partial_threshold=0.0,
+        )
+        assert p.block_on_critical_missing is False
+        assert p.block_on_critical_partial is False
+        assert p.block_on_high_missing is False
+        assert p.critical_partial_threshold == pytest.approx(0.0)
+
+    def test_custom_strict_threshold(self):
+        p = PassPolicy(critical_partial_threshold=0.75)
+        assert p.critical_partial_threshold == pytest.approx(0.75)
+
+    def test_mixed_policy_custom_threshold(self):
+        p = PassPolicy(
+            block_on_critical_missing=True,
+            block_on_critical_partial=True,
+            block_on_high_missing=False,
+            critical_partial_threshold=0.3,
+        )
+        assert p.block_on_critical_missing is True
+        assert p.block_on_high_missing is False
+        assert p.critical_partial_threshold == pytest.approx(0.3)
+
+    def test_field_names(self):
+        field_names = {f.name for f in fields(PassPolicy)}
+        expected = {
+            "block_on_critical_missing",
+            "block_on_critical_partial",
+            "block_on_high_missing",
+            "critical_partial_threshold",
+        }
+        assert expected == field_names
+
+    def test_equality_default_instances(self):
+        """Two default PassPolicy instances should be equal."""
+        assert PassPolicy() == PassPolicy()
+
+    def test_inequality_different_threshold(self):
+        assert PassPolicy(critical_partial_threshold=0.3) != PassPolicy(critical_partial_threshold=0.7)

--- a/tests/test_pass_policy.py
+++ b/tests/test_pass_policy.py
@@ -1,0 +1,349 @@
+"""
+tests/test_pass_policy.py
+==========================
+
+Comprehensive tests for PassPolicy threshold interactions:
+  - Default strict policy
+  - Custom threshold values at and around boundaries
+  - All four configurable fields in isolation and combination
+  - block_on_critical_partial with custom critical_partial_threshold
+  - block_on_high_missing toggle
+  - Optional elements never block regardless of policy
+
+These tests operate purely on _determine_pass() (no LLM calls).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from assert_llm_tools.metrics.note.models import GapItem, PassPolicy
+from assert_llm_tools.metrics.note.evaluate_note import NoteEvaluator
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _ev(policy: PassPolicy | None = None) -> NoteEvaluator:
+    """Return a NoteEvaluator with the given policy and a mocked LLM."""
+    ev = NoteEvaluator(pass_policy=policy)
+    ev.llm = MagicMock(name="mock_llm")
+    return ev
+
+
+def _item(
+    element_id: str = "x",
+    status: str = "present",
+    score: float = 1.0,
+    severity: str = "critical",
+    required: bool = True,
+) -> GapItem:
+    return GapItem(
+        element_id=element_id,
+        status=status,
+        score=score,
+        evidence="",
+        severity=severity,
+        required=required,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Default policy — strict
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDefaultPolicyStrict:
+
+    def test_all_present_passes(self):
+        ev = _ev()
+        items = [
+            _item("a", "present", 1.0, "critical", True),
+            _item("b", "present", 0.9, "high", True),
+            _item("c", "present", 0.8, "medium", False),
+        ]
+        assert ev._determine_pass(items) is True
+
+    def test_critical_required_missing_fails(self):
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_high_required_missing_fails(self):
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "high", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_critical_partial_below_half_fails(self):
+        ev = _ev()
+        items = [_item("a", "partial", 0.49, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_critical_partial_at_half_passes(self):
+        """Score == 0.5 (the default threshold) should NOT block (strict less-than)."""
+        ev = _ev()
+        items = [_item("a", "partial", 0.5, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_critical_partial_above_half_passes(self):
+        ev = _ev()
+        items = [_item("a", "partial", 0.8, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_medium_required_missing_passes(self):
+        """Medium-severity required element missing does NOT block under default policy."""
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "medium", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_low_required_missing_passes(self):
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "low", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_high_partial_does_not_block(self):
+        """High partial with low score does NOT block — only high MISSING blocks."""
+        ev = _ev()
+        items = [_item("a", "partial", 0.1, "high", True)]
+        assert ev._determine_pass(items) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# block_on_critical_missing toggle
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBlockOnCriticalMissing:
+
+    def test_enabled_critical_missing_fails(self):
+        ev = _ev(PassPolicy(block_on_critical_missing=True))
+        items = [_item("a", "missing", 0.0, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_disabled_critical_missing_passes(self):
+        ev = _ev(PassPolicy(
+            block_on_critical_missing=False,
+            block_on_critical_partial=False,
+            block_on_high_missing=False,
+        ))
+        items = [_item("a", "missing", 0.0, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_disabled_critical_missing_but_high_missing_still_blocks(self):
+        ev = _ev(PassPolicy(
+            block_on_critical_missing=False,
+            block_on_high_missing=True,
+        ))
+        items = [
+            _item("a", "missing", 0.0, "critical", True),
+            _item("b", "missing", 0.0, "high", True),
+        ]
+        assert ev._determine_pass(items) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# block_on_high_missing toggle
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBlockOnHighMissing:
+
+    def test_enabled_high_missing_fails(self):
+        ev = _ev(PassPolicy(block_on_high_missing=True))
+        items = [_item("a", "missing", 0.0, "high", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_disabled_high_missing_passes(self):
+        ev = _ev(PassPolicy(block_on_high_missing=False))
+        items = [_item("a", "missing", 0.0, "high", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_disabled_high_missing_critical_still_blocks(self):
+        ev = _ev(PassPolicy(block_on_high_missing=False, block_on_critical_missing=True))
+        items = [
+            _item("a", "missing", 0.0, "high", True),    # high missing — disabled, should not block
+            _item("b", "missing", 0.0, "critical", True), # critical missing — should block
+        ]
+        assert ev._determine_pass(items) is False
+
+    def test_high_present_does_not_affect_pass(self):
+        ev = _ev(PassPolicy(block_on_high_missing=True))
+        items = [_item("a", "present", 1.0, "high", True)]
+        assert ev._determine_pass(items) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# block_on_critical_partial + critical_partial_threshold combinations
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCriticalPartialThreshold:
+
+    def test_default_threshold_0_5_boundary_exact(self):
+        """Exact default threshold: score==0.5 should NOT block (< operator)."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.5))
+        items = [_item("a", "partial", 0.5, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_default_threshold_0_5_just_below(self):
+        """Just below default threshold: 0.499 should block."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.5))
+        items = [_item("a", "partial", 0.499, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_threshold_0_7_score_0_65_fails(self):
+        """Custom threshold 0.7: score 0.65 is below → block."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.7))
+        items = [_item("a", "partial", 0.65, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_threshold_0_7_score_0_7_passes(self):
+        """Custom threshold 0.7: score at exactly 0.7 → NOT blocked (< operator)."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.7))
+        items = [_item("a", "partial", 0.7, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_threshold_0_7_score_0_75_passes(self):
+        """Custom threshold 0.7: score 0.75 → pass."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.7))
+        items = [_item("a", "partial", 0.75, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_threshold_0_3_score_0_25_fails(self):
+        """Lenient threshold 0.3: score 0.25 → block."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.3))
+        items = [_item("a", "partial", 0.25, "critical", True)]
+        assert ev._determine_pass(items) is False
+
+    def test_threshold_0_3_score_0_3_passes(self):
+        """Lenient threshold 0.3: score exactly 0.3 → pass (< operator)."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.3))
+        items = [_item("a", "partial", 0.3, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_block_on_critical_partial_disabled_ignores_threshold(self):
+        """block_on_critical_partial=False → even score 0.0 partial does not block."""
+        ev = _ev(PassPolicy(
+            block_on_critical_partial=False,
+            critical_partial_threshold=0.99,  # would block anything below 0.99 if enabled
+        ))
+        items = [_item("a", "partial", 0.01, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+    def test_threshold_does_not_affect_high_partial(self):
+        """critical_partial_threshold has no effect on high-severity partial elements."""
+        ev = _ev(PassPolicy(
+            block_on_critical_partial=True,
+            block_on_high_missing=True,
+            critical_partial_threshold=0.9,
+        ))
+        items = [
+            _item("a", "partial", 0.1, "high", True),   # high partial — threshold not applicable
+        ]
+        # High partial (not missing) should NOT block regardless of threshold
+        assert ev._determine_pass(items) is True
+
+    def test_threshold_zero_always_passes_partial(self):
+        """Threshold of 0.0 means any partial score (even 0.001) passes."""
+        ev = _ev(PassPolicy(block_on_critical_partial=True, critical_partial_threshold=0.0))
+        items = [_item("a", "partial", 0.001, "critical", True)]
+        assert ev._determine_pass(items) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Optional elements never block
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestOptionalElementsNeverBlock:
+
+    def test_optional_critical_missing_does_not_block(self):
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "critical", required=False)]
+        assert ev._determine_pass(items) is True
+
+    def test_optional_high_missing_does_not_block(self):
+        ev = _ev()
+        items = [_item("a", "missing", 0.0, "high", required=False)]
+        assert ev._determine_pass(items) is True
+
+    def test_optional_critical_partial_below_threshold_does_not_block(self):
+        ev = _ev()
+        items = [_item("a", "partial", 0.1, "critical", required=False)]
+        assert ev._determine_pass(items) is True
+
+    def test_mixed_optional_blocking_required_blocks(self):
+        """If required element blocks, optional elements must not override."""
+        ev = _ev()
+        items = [
+            _item("a", "missing", 0.0, "critical", required=True),   # → blocks
+            _item("b", "present", 1.0, "high", required=False),       # → OK
+        ]
+        assert ev._determine_pass(items) is False
+
+    def test_only_optional_elements_passes(self):
+        """Report with only optional elements always passes, regardless of status."""
+        ev = _ev()
+        items = [
+            _item("a", "missing", 0.0, "critical", required=False),
+            _item("b", "partial", 0.1, "high", required=False),
+            _item("c", "missing", 0.0, "low", required=False),
+        ]
+        assert ev._determine_pass(items) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Full lenient policy
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestFullyLenientPolicy:
+
+    def test_all_disabled_everything_passes(self):
+        """With all block flags disabled, even worst-case items should pass."""
+        ev = _ev(PassPolicy(
+            block_on_critical_missing=False,
+            block_on_critical_partial=False,
+            block_on_high_missing=False,
+        ))
+        items = [
+            _item("a", "missing", 0.0, "critical", True),
+            _item("b", "missing", 0.0, "high", True),
+            _item("c", "partial", 0.0, "critical", True),
+        ]
+        assert ev._determine_pass(items) is True
+
+    def test_all_disabled_empty_list_passes(self):
+        ev = _ev(PassPolicy(
+            block_on_critical_missing=False,
+            block_on_critical_partial=False,
+            block_on_high_missing=False,
+        ))
+        assert ev._determine_pass([]) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Multiple blocking conditions
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestMultipleBlockingConditions:
+
+    def test_multiple_required_critical_missing_all_block(self):
+        """Any of multiple missing critical elements should block."""
+        ev = _ev()
+        items = [
+            _item("a", "missing", 0.0, "critical", True),
+            _item("b", "missing", 0.0, "critical", True),
+        ]
+        assert ev._determine_pass(items) is False
+
+    def test_one_present_one_missing_blocks(self):
+        """One present, one critical missing → blocked by the missing one."""
+        ev = _ev()
+        items = [
+            _item("a", "present", 1.0, "critical", True),
+            _item("b", "missing", 0.0, "critical", True),
+        ]
+        assert ev._determine_pass(items) is False
+
+    def test_critical_partial_and_high_missing_both_would_block(self):
+        """With default policy, both blocking conditions active → fails."""
+        ev = _ev()
+        items = [
+            _item("a", "partial", 0.3, "critical", True),  # blocks (partial < 0.5)
+            _item("b", "missing", 0.0, "high", True),       # also blocks
+        ]
+        assert ev._determine_pass(items) is False


### PR DESCRIPTION
## END-85: Phase 1 Unit Test Suite

### Summary

Adds a comprehensive unit test suite under `tests/` covering the evaluation engine and all supporting modules introduced this sprint. 199 tests, all green in 0.13s.

---

### What's in the suite

| File | Tests | What it covers |
|---|---|---|
| `tests/conftest.py` | — | Shared boto3/botocore/openai stubs + BedrockLLM patch applied once for all modules |
| `tests/test_evaluation_engine.py` | 88 | `NoteEvaluator` (init defaults, parser, scorer, stats, full pipeline), `evaluate_note()` top-level entry, custom_instruction propagation, verbose mode, summary fallback, structural/import checks |
| `tests/test_loader.py` | 34 | `load_framework()` with dict passthrough, built-in ID, custom YAML paths, error paths; `_validate_framework()` for all top-level and per-element fields |
| `tests/test_models.py` | 41 | `GapItem`, `GapReport`, `GapReportStats`, `PassPolicy` — dataclass identity, all field defaults and types, equality, boundary values, per-instance metadata |
| `tests/test_pass_policy.py` | 36 | `_determine_pass()` — default strict policy, all four configurable field toggles, `critical_partial_threshold` at/above/below boundary (0.3, 0.5, 0.7), optional elements never block, fully lenient policy, multiple blocking conditions |

### Coverage highlights

- **Parser edge cases**: garbled response, empty response, case-insensitive STATUS, missing SCORE field, score correction for STATUS=missing (>0.2 → 0.0), evidence 'None'/'None found' → empty string
- **Weighting**: required 2×, optional 1×; verified with arithmetic assertions  
- **PassPolicy threshold semantics**: uses strict `<` operator — score at threshold passes, score below fails; verified at 0.3, 0.5, and 0.7
- **Pipeline call count**: evaluated against FCA framework (9 elements) → asserts exactly 10 LLM calls (9 element + 1 summary)
- **Consolidation**: `tests/conftest.py` replaces per-file stub boilerplate from root-level test files; root-level `test_evaluate_note.py` (66 tests) still passes unchanged

### Test run

```
199 passed in 0.13s
```

Resolves END-85.