### PR TITLE
feat(END-91): implement assert-eval package

### DIFF
--- a/.github/workflows/ci-assert-eval.yml
+++ b/.github/workflows/ci-assert-eval.yml
@@ -1,0 +1,31 @@
+name: CI — assert-eval
+
+on:
+  push:
+    paths:
+      - 'packages/assert-eval/**'
+      - 'packages/assert-core/**'
+  pull_request:
+    paths:
+      - 'packages/assert-eval/**'
+      - 'packages/assert-core/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install assert-core
+        run: pip install -e "packages/assert-core"
+      - name: Install assert-eval
+        run: pip install -e "packages/assert-eval[dev]"
+      - name: Lint
+        run: ruff check packages/assert-eval/assert_eval/
+      - name: Run smoke tests
+        run: pytest packages/assert-eval/tests/ -v

--- a/.github/workflows/publish-assert-eval.yml
+++ b/.github/workflows/publish-assert-eval.yml
@@ -1,0 +1,46 @@
+name: Publish assert-eval to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/assert-eval-v')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install assert-core (build-time dependency)
+        run: pip install -e "packages/assert-core"
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build packages/assert-eval/
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: packages/assert-eval/dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    environment:
+      name: pipit
+      url: https://pypi.org/p/assert-eval
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/packages/assert-core/assert_core/metrics/__init__.py
+++ b/packages/assert-core/assert_core/metrics/__init__.py
@@ -1,5 +1,5 @@
 """assert-core metrics: base classes shared by assert-review and assert-eval."""
 
-from .base import BaseCalculator
+from .base import BaseCalculator, SummaryMetricCalculator
 
-__all__ = ["BaseCalculator"]
+__all__ = ["BaseCalculator", "SummaryMetricCalculator"]

--- a/packages/assert-eval/assert_eval/__init__.py
+++ b/packages/assert-eval/assert_eval/__init__.py
@@ -1,0 +1,7 @@
+"""assert-eval: LLM-based summary quality evaluation."""
+
+from assert_core.llm.config import LLMConfig
+
+from .evaluate_summary import AVAILABLE_SUMMARY_METRICS, evaluate_summary
+
+__all__ = ["evaluate_summary", "AVAILABLE_SUMMARY_METRICS", "LLMConfig"]

--- a/packages/assert-eval/assert_eval/evaluate_summary.py
+++ b/packages/assert-eval/assert_eval/evaluate_summary.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Dict, List, Optional
+
+from assert_core.llm.config import LLMConfig
+
+from .metrics.coverage import calculate_coverage
+from .metrics.factual_alignment import calculate_factual_alignment
+from .metrics.factual_consistency import calculate_factual_consistency
+from .metrics.topic_preservation import calculate_topic_preservation
+
+logger = logging.getLogger(__name__)
+
+AVAILABLE_SUMMARY_METRICS = [
+    "coverage",
+    "factual_consistency",
+    "factual_alignment",
+    "topic_preservation",
+]
+
+LLM_REQUIRED_SUMMARY_METRICS = [
+    "coverage",
+    "factual_consistency",
+    "factual_alignment",
+    "topic_preservation",
+]
+
+
+def evaluate_summary(
+    full_text: str,
+    summary: str,
+    metrics: Optional[List[str]] = None,
+    llm_config: Optional[LLMConfig] = None,
+    custom_prompt_instructions: Optional[Dict[str, str]] = None,
+    verbose: bool = False,
+) -> Dict[str, float]:
+    """
+    Evaluate a summary using the specified metrics.
+
+    Args:
+        full_text: Original source text
+        summary: Generated summary to evaluate
+        metrics: List of metrics to calculate. Defaults to all available metrics.
+        llm_config: Configuration for LLM-based metrics (required for all metrics)
+        custom_prompt_instructions: Optional dict mapping metric names to custom prompt
+            instructions. Example: {"coverage": "Apply strict scientific standards"}
+        verbose: If True, include detailed analysis for LLM-based metrics showing
+            individual claims/topics and their verification status
+
+    Returns:
+        Dictionary containing scores for each requested metric
+    """
+    if metrics is None:
+        metrics = AVAILABLE_SUMMARY_METRICS
+
+    invalid = set(metrics) - set(AVAILABLE_SUMMARY_METRICS)
+    if invalid:
+        raise ValueError(f"Invalid metrics: {invalid}")
+
+    llm_metrics = set(metrics) & set(LLM_REQUIRED_SUMMARY_METRICS)
+    if llm_metrics and llm_config is None:
+        raise ValueError(f"LLM configuration required for metrics: {llm_metrics}")
+
+    results = {}
+
+    for metric in metrics:
+        if metric == "coverage":
+            if "coverage" not in results:
+                instruction = custom_prompt_instructions.get("coverage") if custom_prompt_instructions else None
+                results.update(calculate_coverage(full_text, summary, llm_config, instruction, verbose=verbose))
+
+        elif metric == "factual_consistency":
+            if "factual_consistency" not in results:
+                instruction = custom_prompt_instructions.get("factual_consistency") if custom_prompt_instructions else None
+                results.update(calculate_factual_consistency(full_text, summary, llm_config, instruction, verbose=verbose))
+
+        elif metric == "factual_alignment":
+            instruction = custom_prompt_instructions.get("factual_alignment") if custom_prompt_instructions else None
+            results.update(
+                calculate_factual_alignment(
+                    full_text,
+                    summary,
+                    llm_config,
+                    instruction,
+                    verbose=verbose,
+                    _precomputed_coverage=results if "coverage" in results else None,
+                    _precomputed_consistency=results if "factual_consistency" in results else None,
+                )
+            )
+
+        elif metric == "topic_preservation":
+            instruction = custom_prompt_instructions.get("topic_preservation") if custom_prompt_instructions else None
+            results.update(calculate_topic_preservation(full_text, summary, llm_config, instruction, verbose=verbose))
+
+    return results

--- a/packages/assert-eval/assert_eval/metrics/__init__.py
+++ b/packages/assert-eval/assert_eval/metrics/__init__.py
@@ -1,0 +1,13 @@
+"""assert-eval metrics: summary quality evaluation calculators."""
+
+from .coverage import calculate_coverage
+from .factual_alignment import calculate_factual_alignment
+from .factual_consistency import calculate_factual_consistency
+from .topic_preservation import calculate_topic_preservation
+
+__all__ = [
+    "calculate_coverage",
+    "calculate_factual_consistency",
+    "calculate_factual_alignment",
+    "calculate_topic_preservation",
+]

--- a/packages/assert-eval/assert_eval/metrics/coverage.py
+++ b/packages/assert-eval/assert_eval/metrics/coverage.py
@@ -1,0 +1,169 @@
+from typing import Dict, List, Optional
+
+from assert_core.llm.config import LLMConfig
+from assert_core.metrics.base import SummaryMetricCalculator
+
+
+class CoverageCalculator(SummaryMetricCalculator):
+    """
+    Calculator for evaluating coverage/completeness of summaries.
+
+    Measures how well a summary covers the claims from the reference text
+    by extracting claims from the reference and checking if they appear in the summary.
+    This provides a measure of completeness/recall - what percentage of the source
+    information is captured in the summary.
+    """
+
+    def __init__(self, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None, verbose: bool = False):
+        """
+        Initialize coverage calculator.
+
+        Args:
+            llm_config: Configuration for LLM
+            custom_instruction: Optional custom instruction to add to the LLM prompt
+            verbose: Whether to include detailed claim-level analysis in the output
+        """
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+        self.verbose = verbose
+
+    def _check_claims_in_summary_batch(self, claims: List[str], summary: str) -> List[bool]:
+        """
+        Check if claims from the reference text are present in the summary.
+
+        Args:
+            claims: List of claims from reference text to check
+            summary: Summary text to check against
+
+        Returns:
+            List of boolean values indicating if each claim is present in the summary
+        """
+        if not claims:
+            return []
+
+        claims_text = "\n".join(f"Claim {i+1}: {claim}" for i, claim in enumerate(claims))
+        prompt = f"""You are a coverage verification assistant that determines if claims from a source document are present in a summary.
+
+For each claim below, determine if the information from that claim appears in the summary (even if worded differently or paraphrased).
+
+Summary:
+```
+{summary}
+```
+
+Claims from source document to check:
+{claims_text}
+
+Respond with EXACTLY one line per claim, containing ONLY the word 'supported' or 'unsupported'.
+- 'supported' = the claim's information appears in the summary
+- 'unsupported' = the claim's information is missing from the summary
+
+Do not include any explanation, reasoning, or numbering in your response.
+
+For example, if there are 3 claims, your response should look exactly like:
+supported
+unsupported
+supported"""
+
+        if self.custom_instruction:
+            prompt += f"\n\nAdditional Instructions:\n{self.custom_instruction}"
+
+        response = self.llm.generate(prompt, max_tokens=300)
+
+        # Clean up response and split into lines
+        lines = [line.strip() for line in response.strip().split("\n") if line.strip()]
+
+        # Filter out any lines that don't contain our expected response formats
+        # Accept both new (supported/unsupported) and old (present/missing) keywords
+        valid_lines = []
+        for line in lines:
+            line_lower = line.lower()
+            if (
+                "supported" in line_lower
+                or "unsupported" in line_lower
+                or "present" in line_lower
+                or "missing" in line_lower
+            ):
+                valid_lines.append(line_lower)
+
+        # Make sure we have a result for each claim
+        results = valid_lines[: len(claims)]  # Truncate if too many
+        if len(results) < len(claims):
+            # Pad with "unsupported" if too few (being conservative - assume not covered)
+            results.extend(["unsupported"] * (len(claims) - len(results)))
+
+        # Determine if each result indicates presence
+        present = []
+        for result in results:
+            is_present = ("supported" in result and "unsupported" not in result) or (
+                "present" in result and "not present" not in result
+            )
+            present.append(is_present)
+
+        return present
+
+    def calculate_score(self, reference: str, candidate: str) -> Dict[str, float]:
+        """
+        Calculate coverage score for a summary based on coverage of source claims.
+
+        Args:
+            reference: Original reference text
+            candidate: Summary to evaluate
+
+        Returns:
+            Dictionary with coverage score and claim statistics
+        """
+        reference_claims = self._extract_claims(reference, context="source")
+
+        if not reference_claims:
+            return {
+                "coverage": 1.0,
+                "reference_claims_count": 0,
+                "claims_in_summary_count": 0,
+            }
+
+        claims_present_results = self._check_claims_in_summary_batch(reference_claims, candidate)
+        claims_in_summary_count = sum(claims_present_results)
+        coverage_score = claims_in_summary_count / len(reference_claims)
+
+        result = {
+            "coverage": coverage_score,
+            "reference_claims_count": len(reference_claims),
+            "claims_in_summary_count": claims_in_summary_count,
+        }
+
+        if self.verbose:
+            result["claims_analysis"] = [
+                {"claim": claim, "is_covered": is_present}
+                for claim, is_present in zip(reference_claims, claims_present_results)
+            ]
+
+        return result
+
+
+def calculate_coverage(
+    reference: str,
+    candidate: str,
+    llm_config: Optional[LLMConfig] = None,
+    custom_instruction: Optional[str] = None,
+    verbose: bool = False,
+) -> Dict[str, float]:
+    """
+    Calculate coverage score by measuring how many claims from the reference appear in the summary.
+
+    Args:
+        reference (str): The original full text
+        candidate (str): The summary to evaluate
+        llm_config (Optional[LLMConfig]): Configuration for the LLM to use
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt
+        verbose (bool): If True, include detailed claim-level analysis
+
+    Returns:
+        Dict[str, float]: Dictionary containing:
+            - coverage: Score from 0-1
+            - reference_claims_count: Total claims extracted from reference
+            - claims_in_summary_count: Number of reference claims present in summary
+            - claims_analysis (only if verbose=True): List of dicts with claim text and coverage status
+    """
+    calculator = CoverageCalculator(llm_config, custom_instruction=custom_instruction, verbose=verbose)
+    return calculator.calculate_score(reference, candidate)

--- a/packages/assert-eval/assert_eval/metrics/factual_alignment.py
+++ b/packages/assert-eval/assert_eval/metrics/factual_alignment.py
@@ -1,0 +1,90 @@
+from typing import Dict, Optional
+
+from assert_core.llm.config import LLMConfig
+
+from .coverage import calculate_coverage
+from .factual_consistency import calculate_factual_consistency
+
+
+def calculate_factual_alignment(
+    reference: str,
+    candidate: str,
+    llm_config: Optional[LLMConfig] = None,
+    custom_instruction: Optional[str] = None,
+    verbose: bool = False,
+    _precomputed_coverage: Optional[Dict[str, float]] = None,
+    _precomputed_consistency: Optional[Dict[str, float]] = None,
+) -> Dict[str, float]:
+    """
+    Calculate factual alignment score as the F1 score combining coverage and factual consistency.
+
+    This metric provides a balanced measure of summary quality by combining:
+    - Coverage (recall): What percentage of source claims appear in the summary
+    - Factual Consistency (precision): What percentage of summary claims are supported by the source
+
+    The F1 score is the harmonic mean of these two metrics, providing a single score that
+    balances completeness and accuracy.
+
+    Args:
+        reference (str): The original full text
+        candidate (str): The summary to evaluate
+        llm_config (Optional[LLMConfig]): Configuration for the LLM to use
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt
+        verbose (bool): If True, include detailed claim-level analysis from both metrics
+        _precomputed_coverage (Optional[Dict[str, float]]): Internal parameter to pass
+            precomputed coverage results and avoid redundant LLM calls
+        _precomputed_consistency (Optional[Dict[str, float]]): Internal parameter to pass
+            precomputed consistency results and avoid redundant LLM calls
+
+    Returns:
+        Dict[str, float]: Dictionary containing:
+            - factual_alignment: F1 score combining coverage and factual_consistency (0-1)
+            - coverage: Recall score
+            - factual_consistency: Precision score
+            - reference_claims_count: Total claims in reference
+            - summary_claims_count: Total claims in summary
+            - claims_in_summary_count: Source claims found in summary
+            - supported_claims_count: Summary claims supported by source
+            - unsupported_claims_count: Summary claims not supported by source
+            - coverage_claims_analysis (only if verbose=True)
+            - consistency_claims_analysis (only if verbose=True)
+    """
+    if _precomputed_coverage is not None and "coverage" in _precomputed_coverage:
+        coverage_results = _precomputed_coverage
+        coverage_score = coverage_results["coverage"]
+    else:
+        coverage_results = calculate_coverage(reference, candidate, llm_config, custom_instruction, verbose=verbose)
+        coverage_score = coverage_results["coverage"]
+
+    if _precomputed_consistency is not None and "factual_consistency" in _precomputed_consistency:
+        consistency_results = _precomputed_consistency
+        consistency_score = consistency_results["factual_consistency"]
+    else:
+        consistency_results = calculate_factual_consistency(
+            reference, candidate, llm_config, custom_instruction, verbose=verbose
+        )
+        consistency_score = consistency_results["factual_consistency"]
+
+    if coverage_score + consistency_score > 0:
+        factual_alignment_score = 2 * (coverage_score * consistency_score) / (coverage_score + consistency_score)
+    else:
+        factual_alignment_score = 0.0
+
+    result = {
+        "factual_alignment": factual_alignment_score,
+        "coverage": coverage_score,
+        "factual_consistency": consistency_score,
+        "reference_claims_count": coverage_results["reference_claims_count"],
+        "claims_in_summary_count": coverage_results["claims_in_summary_count"],
+        "summary_claims_count": consistency_results["summary_claims_count"],
+        "supported_claims_count": consistency_results["supported_claims_count"],
+        "unsupported_claims_count": consistency_results["unsupported_claims_count"],
+    }
+
+    if verbose:
+        if "claims_analysis" in coverage_results:
+            result["coverage_claims_analysis"] = coverage_results["claims_analysis"]
+        if "claims_analysis" in consistency_results:
+            result["consistency_claims_analysis"] = consistency_results["claims_analysis"]
+
+    return result

--- a/packages/assert-eval/assert_eval/metrics/factual_consistency.py
+++ b/packages/assert-eval/assert_eval/metrics/factual_consistency.py
@@ -1,0 +1,156 @@
+from typing import Dict, List, Optional
+
+from assert_core.llm.config import LLMConfig
+from assert_core.metrics.base import SummaryMetricCalculator
+
+
+class FactualConsistencyCalculator(SummaryMetricCalculator):
+    """
+    Calculator for evaluating factual consistency of summaries.
+
+    Identifies claims in the summary that are supported or unsupported by the reference text.
+    This provides a measure of precision/accuracy - what percentage of summary claims
+    are factually grounded in the source material.
+    """
+
+    def __init__(self, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None, verbose: bool = False):
+        """
+        Initialize factual consistency calculator.
+
+        Args:
+            llm_config: Configuration for LLM
+            custom_instruction: Optional custom instruction to add to the LLM prompt
+            verbose: Whether to include detailed claim-level analysis in the output
+        """
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+        self.verbose = verbose
+
+    def _verify_claims_batch(self, claims: List[str], context: str) -> List[bool]:
+        """
+        Verify if claims are supported by the reference text.
+
+        Args:
+            claims: List of claims to verify
+            context: Reference text to check against
+
+        Returns:
+            List of boolean values indicating if each claim is supported (True) or unsupported (False)
+        """
+        if not claims:
+            return []
+
+        claims_text = "\n".join(f"Claim {i+1}: {claim}" for i, claim in enumerate(claims))
+        prompt = f"""
+        You are a factual consistency verification assistant that determines if claims in a summary are supported by the original text.
+
+        For each claim below, determine if it is supported by or can be directly inferred from the original text.
+
+        Original text:
+        ```
+        {context}
+        ```
+
+        Claims to verify:
+        {claims_text}
+
+        Respond with EXACTLY one line per claim, containing ONLY the word 'supported' or 'unsupported'.
+        Do not include any explanation, reasoning, or numbering in your response.
+
+        For example, if there are 3 claims, your response should look exactly like:
+        supported
+        unsupported
+        supported"""
+
+        if self.custom_instruction:
+            prompt += f"\n\nAdditional Instructions:\n{self.custom_instruction}"
+
+        response = self.llm.generate(prompt, max_tokens=300)
+
+        lines = [line.strip() for line in response.strip().split("\n") if line.strip()]
+
+        valid_lines = []
+        for line in lines:
+            line_lower = line.lower()
+            if "supported" in line_lower or "unsupported" in line_lower:
+                valid_lines.append(line_lower)
+
+        results = valid_lines[: len(claims)]
+        if len(results) < len(claims):
+            results.extend(["unsupported"] * (len(claims) - len(results)))
+
+        supported = []
+        for result in results:
+            is_supported = "unsupported" not in result or "not unsupported" in result
+            supported.append(is_supported)
+
+        return supported
+
+    def calculate_score(self, reference: str, candidate: str) -> Dict[str, float]:
+        """
+        Calculate factual consistency score for a summary.
+
+        Args:
+            reference: Original reference text
+            candidate: Summary to evaluate
+
+        Returns:
+            Dictionary with factual consistency score and claim statistics
+        """
+        summary_claims = self._extract_claims(candidate, context="summary")
+
+        if not summary_claims:
+            return {
+                "factual_consistency": 1.0,
+                "summary_claims_count": 0,
+                "unsupported_claims_count": 0,
+            }
+
+        supported_results = self._verify_claims_batch(summary_claims, reference)
+        supported_claims_count = sum(supported_results)
+        unsupported_claims_count = len(summary_claims) - supported_claims_count
+        factual_consistency_score = supported_claims_count / len(summary_claims)
+
+        result = {
+            "factual_consistency": factual_consistency_score,
+            "summary_claims_count": len(summary_claims),
+            "supported_claims_count": supported_claims_count,
+            "unsupported_claims_count": unsupported_claims_count,
+        }
+
+        if self.verbose:
+            result["claims_analysis"] = [
+                {"claim": claim, "is_supported": is_supported}
+                for claim, is_supported in zip(summary_claims, supported_results)
+            ]
+
+        return result
+
+
+def calculate_factual_consistency(
+    reference: str,
+    candidate: str,
+    llm_config: Optional[LLMConfig] = None,
+    custom_instruction: Optional[str] = None,
+    verbose: bool = False,
+) -> Dict[str, float]:
+    """
+    Calculate factual consistency score by verifying if claims in the summary are supported by the reference.
+
+    Args:
+        reference (str): The original full text
+        candidate (str): The summary to evaluate
+        llm_config (Optional[LLMConfig]): Configuration for the LLM to use
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt
+        verbose (bool): If True, include detailed claim-level analysis
+
+    Returns:
+        Dict[str, float]: Dictionary containing:
+            - factual_consistency: Score from 0-1
+            - summary_claims_count: Total claims extracted from summary
+            - supported_claims_count: Number of summary claims supported by reference
+            - unsupported_claims_count: Number of summary claims not supported by reference
+            - claims_analysis (only if verbose=True): List of dicts with claim text and support status
+    """
+    calculator = FactualConsistencyCalculator(llm_config, custom_instruction=custom_instruction, verbose=verbose)
+    return calculator.calculate_score(reference, candidate)

--- a/packages/assert-eval/assert_eval/metrics/topic_preservation.py
+++ b/packages/assert-eval/assert_eval/metrics/topic_preservation.py
@@ -1,0 +1,124 @@
+from typing import Dict, List, Optional
+
+from assert_core.llm.config import LLMConfig
+from assert_core.metrics.base import SummaryMetricCalculator
+
+
+class TopicPreservationCalculator(SummaryMetricCalculator):
+    """
+    Calculator for evaluating topic preservation in summaries.
+
+    Measures how well a summary preserves the main topics from the original text.
+    """
+
+    def __init__(self, llm_config: Optional[LLMConfig] = None, custom_instruction: Optional[str] = None, verbose: bool = False):
+        """
+        Initialize topic preservation calculator.
+
+        Args:
+            llm_config: Configuration for LLM
+            custom_instruction: Optional custom instruction to add to the LLM prompt
+            verbose: Whether to include detailed topic-level analysis in the output
+        """
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+        self.verbose = verbose
+
+    def _check_topics_in_summary(self, topics: List[str], summary: str) -> List[bool]:
+        """
+        Check if topics from the original text are present in the summary.
+
+        Args:
+            topics: List of topics to check
+            summary: Summary text to analyze
+
+        Returns:
+            List of boolean values indicating if each topic is present
+        """
+        topics_str = "\n".join([f"- {topic}" for topic in topics])
+        prompt = f"""
+        System: You are a topic coverage analysis assistant. Your task is to check if specific topics are present in a summary.
+
+        For each topic listed below, respond with ONLY "yes" or "no" to indicate if the topic is covered in the summary.
+        Respond with one answer per line, nothing else.
+
+        Summary: {summary}
+
+        Topics to check:
+        {topics_str}
+
+        Answer with yes/no for each topic:"""
+
+        if self.custom_instruction:
+            prompt += f"\n\nAdditional Instructions:\n{self.custom_instruction}"
+
+        response = self.llm.generate(prompt, max_tokens=500)
+        results = [line.strip().lower() for line in response.strip().split("\n") if line.strip()]
+        return ["yes" in result for result in results]
+
+    def calculate_score(self, reference: str, candidate: str) -> Dict[str, float]:
+        """
+        Calculate topic preservation score.
+
+        Args:
+            reference: Original reference text
+            candidate: Summary to evaluate
+
+        Returns:
+            Dictionary with topic preservation score and analysis
+        """
+        reference_topics = self._extract_topics(reference)
+        topic_present = self._check_topics_in_summary(reference_topics, candidate)
+
+        preserved_topics = [topic for topic, present in zip(reference_topics, topic_present) if present]
+        missing_topics = [topic for topic, present in zip(reference_topics, topic_present) if not present]
+
+        topic_preservation_score = len(preserved_topics) / len(reference_topics) if reference_topics else 0.0
+
+        result = {
+            "topic_preservation": topic_preservation_score,
+            "reference_topics_count": len(reference_topics),
+            "preserved_topics_count": len(preserved_topics),
+            "missing_topics_count": len(missing_topics),
+        }
+
+        if self.verbose:
+            result["topics_analysis"] = [
+                {"topic": topic, "is_preserved": present}
+                for topic, present in zip(reference_topics, topic_present)
+            ]
+            result["preserved_topics"] = preserved_topics
+            result["missing_topics"] = missing_topics
+
+        return result
+
+
+def calculate_topic_preservation(
+    reference: str,
+    candidate: str,
+    llm_config: Optional[LLMConfig] = None,
+    custom_instruction: Optional[str] = None,
+    verbose: bool = False,
+) -> Dict[str, float]:
+    """
+    Evaluate how well a summary preserves the main topics from the original text.
+
+    Args:
+        reference (str): The original full text
+        candidate (str): The summary to evaluate
+        llm_config (Optional[LLMConfig]): Configuration for the LLM to use
+        custom_instruction (Optional[str]): Custom instruction to add to the LLM prompt
+        verbose (bool): If True, include detailed topic-level analysis
+
+    Returns:
+        Dict[str, float]: Dictionary containing:
+            - topic_preservation: Score from 0-1
+            - reference_topics_count: Total topics extracted from reference
+            - preserved_topics_count: Number of topics preserved in summary
+            - missing_topics_count: Number of topics missing from summary
+            - topics_analysis (only if verbose=True)
+            - preserved_topics (only if verbose=True)
+            - missing_topics (only if verbose=True)
+    """
+    calculator = TopicPreservationCalculator(llm_config, custom_instruction=custom_instruction, verbose=verbose)
+    return calculator.calculate_score(reference, candidate)

--- a/packages/assert-eval/pyproject.toml
+++ b/packages/assert-eval/pyproject.toml
@@ -12,4 +12,17 @@ dependencies = [
     "assert-core>=0.1.0",
 ]
 
-# Implementation coming in END-91
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-cov", "ruff>=0.4"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["assert_eval*"]

--- a/packages/assert-eval/tests/test_smoke.py
+++ b/packages/assert-eval/tests/test_smoke.py
@@ -1,0 +1,178 @@
+"""Smoke tests — assert-eval installs and exports correctly (END-91)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from assert_eval import AVAILABLE_SUMMARY_METRICS, LLMConfig, evaluate_summary
+from assert_eval.metrics import (
+    calculate_coverage,
+    calculate_factual_alignment,
+    calculate_factual_consistency,
+    calculate_topic_preservation,
+)
+
+_REFERENCE = "The company reported $5.2 billion in revenue for Q3 2024, a 15% increase year-over-year."
+_SUMMARY = "The company had $5.2 billion in Q3 2024 revenue, up 15% year-over-year."
+_LLM_CFG = LLMConfig(provider="bedrock", model_id="anthropic.claude-v2", region="us-east-1")
+
+
+# ---------------------------------------------------------------------------
+# Import / API surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_importable():
+    assert evaluate_summary is not None
+    assert AVAILABLE_SUMMARY_METRICS is not None
+    assert LLMConfig is not None
+
+
+def test_available_metrics_list():
+    assert set(AVAILABLE_SUMMARY_METRICS) == {
+        "coverage",
+        "factual_consistency",
+        "factual_alignment",
+        "topic_preservation",
+    }
+
+
+def test_individual_calculators_importable():
+    assert calculate_coverage is not None
+    assert calculate_factual_consistency is not None
+    assert calculate_factual_alignment is not None
+    assert calculate_topic_preservation is not None
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_llm_config_raises():
+    with pytest.raises(ValueError, match="LLM configuration required"):
+        evaluate_summary(_REFERENCE, _SUMMARY, metrics=["coverage"], llm_config=None)
+
+
+def test_invalid_metric_raises():
+    with pytest.raises(ValueError, match="Invalid metrics"):
+        evaluate_summary(_REFERENCE, _SUMMARY, metrics=["nonexistent"], llm_config=_LLM_CFG)
+
+
+# ---------------------------------------------------------------------------
+# Metric execution (mocked LLM)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_generate(responses):
+    """Return a side_effect function that cycles through a list of responses."""
+    call_count = {"n": 0}
+
+    def _generate(prompt, **kwargs):
+        idx = min(call_count["n"], len(responses) - 1)
+        call_count["n"] += 1
+        return responses[idx]
+
+    return _generate
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_coverage(mock_generate, mock_init):
+    # First call: extract claims from reference → 2 claims
+    # Second call: check which claims are in summary → both supported
+    mock_generate.side_effect = _make_mock_generate(
+        [
+            "The company reported $5.2 billion in revenue\nRevenue increased 15% year-over-year",
+            "supported\nsupported",
+        ]
+    )
+    result = calculate_coverage(_REFERENCE, _SUMMARY, _LLM_CFG)
+    assert "coverage" in result
+    assert 0.0 <= result["coverage"] <= 1.0
+    assert "reference_claims_count" in result
+    assert "claims_in_summary_count" in result
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_factual_consistency(mock_generate, mock_init):
+    mock_generate.side_effect = _make_mock_generate(
+        [
+            "The company had $5.2 billion in Q3 2024 revenue\nRevenue was up 15% year-over-year",
+            "supported\nsupported",
+        ]
+    )
+    result = calculate_factual_consistency(_REFERENCE, _SUMMARY, _LLM_CFG)
+    assert "factual_consistency" in result
+    assert 0.0 <= result["factual_consistency"] <= 1.0
+    assert "summary_claims_count" in result
+    assert "supported_claims_count" in result
+    assert "unsupported_claims_count" in result
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_topic_preservation(mock_generate, mock_init):
+    mock_generate.side_effect = _make_mock_generate(
+        [
+            "revenue\nearnings growth",  # topics extracted
+            "yes\nyes",  # both preserved
+        ]
+    )
+    result = calculate_topic_preservation(_REFERENCE, _SUMMARY, _LLM_CFG)
+    assert "topic_preservation" in result
+    assert 0.0 <= result["topic_preservation"] <= 1.0
+    assert "reference_topics_count" in result
+    assert "preserved_topics_count" in result
+    assert "missing_topics_count" in result
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_factual_alignment_uses_precomputed(mock_generate, mock_init):
+    """factual_alignment reuses precomputed coverage/consistency results."""
+    mock_generate.side_effect = _make_mock_generate(
+        [
+            # coverage — extract reference claims
+            "claim one\nclaim two",
+            # coverage — check claims in summary
+            "supported\nsupported",
+            # factual_consistency — extract summary claims
+            "claim a\nclaim b",
+            # factual_consistency — verify claims
+            "supported\nsupported",
+        ]
+    )
+    result = evaluate_summary(
+        _REFERENCE,
+        _SUMMARY,
+        metrics=["coverage", "factual_consistency", "factual_alignment"],
+        llm_config=_LLM_CFG,
+    )
+    assert "coverage" in result
+    assert "factual_consistency" in result
+    assert "factual_alignment" in result
+    # factual_alignment should not trigger extra LLM calls (only 4 calls total)
+    assert mock_generate.call_count == 4
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_evaluate_summary_single_metric(mock_generate, mock_init):
+    mock_generate.side_effect = _make_mock_generate(
+        ["claim one\nclaim two", "supported\nunsupported"]
+    )
+    result = evaluate_summary(_REFERENCE, _SUMMARY, metrics=["coverage"], llm_config=_LLM_CFG)
+    assert list(result.keys()) == ["coverage", "reference_claims_count", "claims_in_summary_count"]
+
+
+@patch("assert_core.llm.bedrock.BedrockLLM._initialize")
+@patch("assert_core.llm.bedrock.BedrockLLM.generate")
+def test_verbose_mode_includes_analysis(mock_generate, mock_init):
+    mock_generate.side_effect = _make_mock_generate(
+        ["claim one\nclaim two", "supported\nsupported"]
+    )
+    result = calculate_coverage(_REFERENCE, _SUMMARY, _LLM_CFG, verbose=True)
+    assert "claims_analysis" in result
+    assert isinstance(result["claims_analysis"], list)


### PR DESCRIPTION
## Summary

- Creates the `assert-eval` standalone PyPI package under `packages/assert-eval/`
- Ports `evaluate_summary()` and 4 metrics from `assert_llm_tools` with imports updated to use `assert-core`
- Adds CI (`ci-assert-eval.yml`) and PyPI publish (`publish-assert-eval.yml`) workflows
- Exports `SummaryMetricCalculator` from `assert-core` metrics `__init__` (non-breaking addition)

**Metrics included:** `coverage`, `factual_consistency`, `factual_alignment`, `topic_preservation`

**Out of scope:** `coherence`, `conciseness`, `redundancy` (require `nltk`), and deprecated `faithfulness`/`hallucination` aliases.

## How to test

### Unit tests (no credentials needed)

```bash
# Install dependencies
pip install -e packages/assert-core
pip install -e "packages/assert-eval[dev]"

# Run smoke tests (mocked LLM, no live API calls)
pytest packages/assert-eval/tests/ -v

# Lint
ruff check packages/assert-eval/assert_eval/
```

Expected: 11 tests pass, lint clean.

### Verify public API

```python
from assert_eval import evaluate_summary, AVAILABLE_SUMMARY_METRICS, LLMConfig

print(AVAILABLE_SUMMARY_METRICS)
# ['coverage', 'factual_consistency', 'factual_alignment', 'topic_preservation']
```

### Live integration test (requires AWS credentials)

```python
from assert_eval import evaluate_summary, LLMConfig

llm = LLMConfig(provider="bedrock", model_id="us.amazon.nova-pro-v1:0", region="us-east-1")

result = evaluate_summary(
    full_text="The company reported $5.2 billion in revenue for Q3 2024, a 15% increase year-over-year.",
    summary="The company had $5.2 billion in Q3 2024 revenue, up 15% year-over-year.",
    metrics=["coverage", "factual_consistency", "factual_alignment"],
    llm_config=llm,
)
print(result)
```

### assert-core regression

```bash
pytest packages/assert-core/tests/ -v
```

Expected: all 13 existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)