### PR TITLE
feat(END-90): implement assert-review package

### DIFF
--- a/.github/workflows/ci-assert-review.yml
+++ b/.github/workflows/ci-assert-review.yml
@@ -1,0 +1,31 @@
+name: CI — assert-review
+
+on:
+  push:
+    paths:
+      - 'packages/assert-review/**'
+      - 'packages/assert-core/**'
+  pull_request:
+    paths:
+      - 'packages/assert-review/**'
+      - 'packages/assert-core/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install assert-core
+        run: pip install -e "packages/assert-core"
+      - name: Install assert-review
+        run: pip install -e "packages/assert-review[dev]"
+      - name: Lint
+        run: ruff check packages/assert-review/assert_review/
+      - name: Run smoke tests
+        run: pytest packages/assert-review/tests/ -v

--- a/.github/workflows/publish-assert-review.yml
+++ b/.github/workflows/publish-assert-review.yml
@@ -1,0 +1,46 @@
+name: Publish assert-review to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/assert-review-v')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install assert-core (build-time dependency)
+        run: pip install -e "packages/assert-core"
+      - name: Build release distributions
+        run: |
+          python -m pip install build
+          python -m build packages/assert-review/
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: packages/assert-review/dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      id-token: write
+    environment:
+      name: pipit
+      url: https://pypi.org/p/assert-review
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/packages/assert-review/README.md
+++ b/packages/assert-review/README.md
@@ -1,0 +1,103 @@
+# assert-review
+
+LLM-based compliance note evaluation for financial services.
+
+Evaluates adviser suitability notes against regulatory framework definitions
+(FCA, MiFID II, etc.), returning structured gap reports with per-element scores,
+evidence, and actionable remediation suggestions.
+
+## Installation
+
+```bash
+pip install assert-review
+```
+
+## Quick Start
+
+```python
+from assert_review import evaluate_note, LLMConfig
+
+llm_config = LLMConfig(
+    provider="bedrock",
+    model_id="anthropic.claude-v2",
+    region="us-east-1",
+)
+
+report = evaluate_note(
+    note_text=open("note.txt").read(),
+    framework="fca_suitability_v1",
+    llm_config=llm_config,
+)
+
+print(f"Result: {'PASS' if report.passed else 'FAIL'} ({report.overall_rating})")
+print(f"Score: {report.overall_score:.2%}")
+```
+
+## CLI
+
+```bash
+# Evaluate a single note
+assert-review evaluate note.txt --framework fca_suitability_v1
+
+# Output as JSON
+assert-review evaluate note.txt --framework fca_suitability_v1 --output json
+
+# Batch evaluate from CSV
+assert-review batch notes.csv --framework fca_suitability_v1 --note-column text
+
+# Use OpenAI instead of Bedrock
+assert-review evaluate note.txt --framework fca_suitability_v1 \
+  --provider openai --model gpt-4o --api-key $OPENAI_API_KEY
+```
+
+## Bundled Frameworks
+
+- `fca_suitability_v1` — FCA COBS 9.2 Suitability Note Framework
+
+Custom frameworks can be supplied as a YAML file path or pre-loaded dict.
+
+## Public API
+
+```python
+from assert_review import (
+    evaluate_note,     # main entry point
+    NoteEvaluator,     # evaluator class for advanced use
+    GapReport,         # full evaluation result
+    GapItem,           # per-element result
+    GapReportStats,    # summary statistics
+    PassPolicy,        # pass/fail threshold configuration
+    LLMConfig,         # re-exported from assert-core
+)
+```
+
+## GapReport Output
+
+```json
+{
+  "framework_id": "fca_suitability_v1",
+  "framework_version": "1.0.0",
+  "passed": true,
+  "overall_score": 0.82,
+  "overall_rating": "Compliant",
+  "summary": "The note meets all 9 FCA suitability requirements...",
+  "stats": { "total_elements": 9, "present_count": 9, ... },
+  "items": [
+    {
+      "element_id": "client_objectives",
+      "status": "present",
+      "score": 0.9,
+      "evidence": "Client states retirement goal in 15 years",
+      "severity": "critical",
+      "required": true,
+      "suggestions": []
+    }
+  ]
+}
+```
+
+## Dependencies
+
+- [assert-core](https://pypi.org/p/assert-core) — shared LLM provider layer
+- PyYAML — framework loading
+
+Supports AWS Bedrock and OpenAI providers via `assert-core`.

--- a/packages/assert-review/assert_review/__init__.py
+++ b/packages/assert-review/assert_review/__init__.py
@@ -1,0 +1,16 @@
+"""assert-review: LLM-based compliance note evaluation for financial services."""
+
+from assert_core.llm.config import LLMConfig
+
+from .evaluate_note import NoteEvaluator, evaluate_note
+from .models import GapItem, GapReport, GapReportStats, PassPolicy
+
+__all__ = [
+    "evaluate_note",
+    "NoteEvaluator",
+    "GapReport",
+    "GapItem",
+    "GapReportStats",
+    "PassPolicy",
+    "LLMConfig",
+]

--- a/packages/assert-review/assert_review/cli.py
+++ b/packages/assert-review/assert_review/cli.py
@@ -24,7 +24,6 @@ from assert_core.llm.config import LLMConfig
 from .evaluate_note import evaluate_note
 from .models import GapReport
 
-
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 def _build_llm_config(args: argparse.Namespace) -> Optional[LLMConfig]:

--- a/packages/assert-review/assert_review/cli.py
+++ b/packages/assert-review/assert_review/cli.py
@@ -1,0 +1,306 @@
+"""
+assert-review CLI — single note and batch CSV evaluation.
+
+Usage:
+    assert-review evaluate <note_file> --framework <id> [options]
+    assert-review batch <csv_file> --framework <id> [options]
+
+Examples:
+    assert-review evaluate note.txt --framework fca_suitability_v1
+    assert-review evaluate note.txt --framework fca_suitability_v1 --output json
+    assert-review batch notes.csv --framework fca_suitability_v1 --note-column text
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from assert_core.llm.config import LLMConfig
+
+from .evaluate_note import evaluate_note
+from .models import GapReport
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _build_llm_config(args: argparse.Namespace) -> Optional[LLMConfig]:
+    """Build LLMConfig from CLI arguments, or return None to use default."""
+    if not hasattr(args, "provider") or args.provider is None:
+        return None
+    kwargs = {"provider": args.provider, "model_id": args.model}
+    if args.provider == "bedrock":
+        kwargs["region"] = args.region
+    elif args.provider == "openai":
+        kwargs["api_key"] = args.api_key
+    return LLMConfig(**kwargs)
+
+
+def _report_to_text(report: GapReport) -> str:
+    """Render a GapReport as human-readable plain text."""
+    lines = [
+        f"Framework : {report.framework_id} v{report.framework_version}",
+        f"Result    : {'PASS' if report.passed else 'FAIL'}  ({report.overall_rating})",
+        f"Score     : {report.overall_score:.2%}",
+        f"Elements  : {report.stats.present_count}/{report.stats.total_elements} present",
+        "",
+        "Summary:",
+        f"  {report.summary}",
+        "",
+    ]
+
+    gaps = [it for it in report.items if it.status != "present"]
+    if gaps:
+        lines.append("Gaps:")
+        for item in gaps:
+            req = "required" if item.required else "optional"
+            lines.append(
+                f"  [{item.severity.upper()}] {item.element_id} — {item.status} "
+                f"(score {item.score:.2f}, {req})"
+            )
+            if item.evidence:
+                lines.append(f"    Evidence : {item.evidence}")
+            for s in item.suggestions:
+                lines.append(f"    Suggest  : {s}")
+    else:
+        lines.append("No gaps identified.")
+
+    return "\n".join(lines)
+
+
+def _report_to_dict(report: GapReport) -> dict:
+    """Convert a GapReport to a JSON-serialisable dict."""
+    return {
+        "framework_id": report.framework_id,
+        "framework_version": report.framework_version,
+        "passed": report.passed,
+        "overall_score": report.overall_score,
+        "overall_rating": report.overall_rating,
+        "summary": report.summary,
+        "stats": {
+            "total_elements": report.stats.total_elements,
+            "required_elements": report.stats.required_elements,
+            "present_count": report.stats.present_count,
+            "partial_count": report.stats.partial_count,
+            "missing_count": report.stats.missing_count,
+            "critical_gaps": report.stats.critical_gaps,
+            "high_gaps": report.stats.high_gaps,
+            "medium_gaps": report.stats.medium_gaps,
+            "low_gaps": report.stats.low_gaps,
+            "required_missing_count": report.stats.required_missing_count,
+        },
+        "items": [
+            {
+                "element_id": it.element_id,
+                "status": it.status,
+                "score": it.score,
+                "evidence": it.evidence,
+                "severity": it.severity,
+                "required": it.required,
+                "notes": it.notes,
+                "suggestions": it.suggestions,
+            }
+            for it in report.items
+        ],
+        "metadata": report.metadata,
+    }
+
+
+# ── Subcommand: evaluate ───────────────────────────────────────────────────────
+
+def cmd_evaluate(args: argparse.Namespace) -> int:
+    """Evaluate a single note file."""
+    note_path = Path(args.note_file)
+    if not note_path.exists():
+        print(f"Error: note file not found: {note_path}", file=sys.stderr)
+        return 1
+
+    note_text = note_path.read_text(encoding="utf-8")
+    llm_config = _build_llm_config(args)
+
+    try:
+        report = evaluate_note(
+            note_text=note_text,
+            framework=args.framework,
+            llm_config=llm_config,
+            verbose=args.verbose,
+        )
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(json.dumps(_report_to_dict(report), indent=2))
+    else:
+        print(_report_to_text(report))
+
+    return 0 if report.passed else 2
+
+
+# ── Subcommand: batch ──────────────────────────────────────────────────────────
+
+def cmd_batch(args: argparse.Namespace) -> int:
+    """Evaluate multiple notes from a CSV file."""
+    csv_path = Path(args.csv_file)
+    if not csv_path.exists():
+        print(f"Error: CSV file not found: {csv_path}", file=sys.stderr)
+        return 1
+
+    llm_config = _build_llm_config(args)
+    results = []
+    errors = 0
+
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        if args.note_column not in (reader.fieldnames or []):
+            print(
+                f"Error: column '{args.note_column}' not found in CSV. "
+                f"Available columns: {reader.fieldnames}",
+                file=sys.stderr,
+            )
+            return 1
+
+        for row_num, row in enumerate(reader, start=2):
+            note_text = row[args.note_column]
+            meta = {k: v for k, v in row.items() if k != args.note_column}
+
+            try:
+                report = evaluate_note(
+                    note_text=note_text,
+                    framework=args.framework,
+                    llm_config=llm_config,
+                    verbose=args.verbose,
+                    metadata=meta,
+                )
+                results.append(_report_to_dict(report))
+            except Exception as exc:
+                errors += 1
+                print(f"Warning: row {row_num} failed: {exc}", file=sys.stderr)
+                results.append({"error": str(exc), "metadata": meta})
+
+    if args.output == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        for i, r in enumerate(results, start=1):
+            if "error" in r:
+                print(f"\n--- Row {i} ERROR: {r['error']} ---")
+            else:
+                # Reconstruct a minimal text summary for batch mode
+                print(f"\n--- Row {i} ---")
+                print(f"Result : {'PASS' if r['passed'] else 'FAIL'}  ({r['overall_rating']})")
+                print(f"Score  : {r['overall_score']:.2%}")
+
+    if errors:
+        print(f"\n{errors} row(s) failed.", file=sys.stderr)
+
+    return 0
+
+
+# ── Parser ─────────────────────────────────────────────────────────────────────
+
+def _add_llm_args(parser: argparse.ArgumentParser) -> None:
+    """Add shared LLM configuration arguments to a subparser."""
+    llm_group = parser.add_argument_group("LLM configuration")
+    llm_group.add_argument(
+        "--provider",
+        choices=["bedrock", "openai"],
+        default="bedrock",
+        help="LLM provider (default: bedrock)",
+    )
+    llm_group.add_argument(
+        "--model",
+        default="anthropic.claude-v2",
+        dest="model",
+        help="Model ID (default: anthropic.claude-v2)",
+    )
+    llm_group.add_argument(
+        "--region",
+        default="us-east-1",
+        help="AWS region for Bedrock (default: us-east-1)",
+    )
+    llm_group.add_argument(
+        "--api-key",
+        default=None,
+        help="API key for OpenAI",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="assert-review",
+        description="LLM-based compliance note evaluation for financial services.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # ── evaluate ──────────────────────────────────────────────────────────────
+    eval_parser = subparsers.add_parser(
+        "evaluate",
+        help="Evaluate a single compliance note file.",
+    )
+    eval_parser.add_argument("note_file", help="Path to the compliance note text file.")
+    eval_parser.add_argument(
+        "--framework",
+        required=True,
+        help="Framework ID (e.g. fca_suitability_v1) or path to a YAML framework file.",
+    )
+    eval_parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    eval_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Include LLM reasoning notes in output.",
+    )
+    _add_llm_args(eval_parser)
+    eval_parser.set_defaults(func=cmd_evaluate)
+
+    # ── batch ─────────────────────────────────────────────────────────────────
+    batch_parser = subparsers.add_parser(
+        "batch",
+        help="Evaluate multiple notes from a CSV file.",
+    )
+    batch_parser.add_argument("csv_file", help="Path to the CSV file.")
+    batch_parser.add_argument(
+        "--framework",
+        required=True,
+        help="Framework ID or path to a YAML framework file.",
+    )
+    batch_parser.add_argument(
+        "--note-column",
+        default="note_text",
+        help="CSV column containing the note text (default: note_text).",
+    )
+    batch_parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    batch_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Include LLM reasoning notes in output.",
+    )
+    _add_llm_args(batch_parser)
+    batch_parser.set_defaults(func=cmd_batch)
+
+    return parser
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/assert-review/assert_review/evaluate_note.py
+++ b/packages/assert-review/assert_review/evaluate_note.py
@@ -1,0 +1,453 @@
+"""
+NoteEvaluator and evaluate_note() — LLM-based compliance note evaluator.
+
+Each framework element is evaluated in a focused, independent LLM call so
+that prompts stay short and scores remain reliable. Results are assembled
+into a structured GapReport.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Union
+
+from assert_core.llm.config import LLMConfig
+from assert_core.metrics.base import BaseCalculator
+
+from .loader import load_framework
+from .models import GapItem, GapReport, GapReportStats, PassPolicy
+
+logger = logging.getLogger(__name__)
+
+
+# ── Public entry point ─────────────────────────────────────────────────────────
+
+def evaluate_note(
+    note_text: str,
+    framework: Union[str, dict],
+    llm_config: Optional[LLMConfig] = None,
+    *,
+    verbose: bool = False,
+    custom_instruction: Optional[str] = None,
+    pass_policy: Optional[PassPolicy] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> GapReport:
+    """
+    Evaluate a compliance note against a regulatory framework definition.
+
+    Uses an LLM to assess each framework element for presence, quality,
+    and supporting evidence within the note text, returning a structured
+    GapReport.
+
+    Args:
+        note_text (str):
+            The full text of the compliance note to evaluate.
+
+        framework (str | dict):
+            Either a path to a YAML framework file, a built-in framework_id
+            string (e.g. "fca_suitability_v1"), or a pre-loaded framework dict.
+
+        llm_config (LLMConfig, optional):
+            LLM provider configuration. If None, a default Bedrock/Claude
+            config is used (consistent with BaseCalculator default).
+
+        verbose (bool):
+            If True, GapItem.notes will contain the raw LLM reasoning for
+            each element assessment. Default: False.
+
+        custom_instruction (str, optional):
+            Additional instruction appended to every element prompt, e.g. to
+            handle firm-specific note formats or terminology.
+
+        pass_policy (PassPolicy, optional):
+            Override the default pass/fail thresholds. If None, the default
+            PassPolicy is used.
+
+        metadata (dict, optional):
+            Arbitrary key/value pairs attached to GapReport.metadata.
+
+    Returns:
+        GapReport: Structured evaluation result.
+
+    Raises:
+        FileNotFoundError: If framework is a string path/id that cannot be resolved.
+        ValueError: If the framework YAML is missing required fields.
+    """
+    calculator = NoteEvaluator(
+        llm_config=llm_config,
+        custom_instruction=custom_instruction,
+        verbose=verbose,
+        pass_policy=pass_policy,
+    )
+    return calculator.evaluate(
+        note_text=note_text,
+        framework=framework,
+        metadata=metadata or {},
+    )
+
+
+# ── NoteEvaluator ─────────────────────────────────────────────────────────────
+
+class NoteEvaluator(BaseCalculator):
+    """
+    LLM-based evaluator for compliance notes against a regulatory framework.
+
+    Extends BaseCalculator, reusing its LLM initialisation and helper methods.
+    Each framework element is evaluated in a separate LLM call to keep prompts
+    focused and scores reliable.
+    """
+
+    def __init__(
+        self,
+        llm_config: Optional[LLMConfig] = None,
+        custom_instruction: Optional[str] = None,
+        verbose: bool = False,
+        pass_policy: Optional[PassPolicy] = None,
+    ) -> None:
+        super().__init__(llm_config)
+        self.custom_instruction = custom_instruction
+        self.verbose = verbose
+        self.pass_policy = pass_policy or PassPolicy()
+
+    # ── Main evaluation pipeline ───────────────────────────────────────────────
+
+    def evaluate(
+        self,
+        note_text: str,
+        framework: Union[str, dict],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> GapReport:
+        """Run the full evaluation pipeline and return a GapReport."""
+        # 1. Load & validate framework
+        fw = load_framework(framework)
+
+        # 2. Evaluate each element independently
+        items: List[GapItem] = []
+        for element in fw["elements"]:
+            logger.debug("Evaluating element: %s", element["id"])
+            item = self._evaluate_element(note_text, element)
+            items.append(item)
+
+        # 4. Generate overall summary via a single additional LLM call
+        summary = self._generate_summary(note_text, fw, items)
+
+        # 5. Compute derived statistics
+        stats = self._compute_stats(items)
+        overall_score = self._compute_overall_score(items)
+        passed = self._determine_pass(items)
+        overall_rating = self._determine_overall_rating(items, passed)
+
+        return GapReport(
+            framework_id=fw["framework_id"],
+            framework_version=fw["version"],
+            passed=passed,
+            overall_score=overall_score,
+            overall_rating=overall_rating,
+            items=items,
+            summary=summary,
+            stats=stats,
+            metadata=metadata or {},
+        )
+
+    # ── Per-element evaluation ─────────────────────────────────────────────────
+
+    def _evaluate_element(
+        self,
+        note_text: str,
+        element: dict,
+    ) -> GapItem:
+        """
+        Evaluate a single framework element against the note text.
+
+        Constructs a focused LLM prompt and parses the structured response
+        into a GapItem.
+        """
+        prompt = self._build_element_prompt(note_text, element)
+        response = self.llm.generate(prompt, max_tokens=400)
+        return self._parse_element_response(response, element)
+
+    def _build_element_prompt(
+        self,
+        note_text: str,
+        element: dict,
+    ) -> str:
+        """Construct the LLM prompt for a single element assessment."""
+        guidance_block = ""
+        if element.get("guidance"):
+            guidance_block = (
+                f"\nEvaluation guidance:\n{element['guidance'].strip()}\n"
+            )
+
+        custom_block = ""
+        if self.custom_instruction:
+            custom_block = (
+                f"\nAdditional instructions:\n{self.custom_instruction.strip()}\n"
+            )
+
+        severity_label = element.get("severity", "medium")
+        required_label = "REQUIRED" if element.get("required", True) else "RECOMMENDED"
+
+        prompt = (
+            f"System: You are a regulatory compliance reviewer assessing whether a "
+            f"financial advice note meets a specific requirement under {severity_label.upper()} "
+            f"severity. Be precise and conservative — only mark an element as 'present' "
+            f"if it is clearly and adequately documented. Partial credit ('partial') "
+            f"applies when the topic is raised but insufficiently documented; 'missing' "
+            f"means there is no meaningful mention whatsoever.\n\n"
+            f"Requirement ({required_label}): {element['description'].strip()}"
+            f"{guidance_block}"
+            f"{custom_block}\n"
+            f"Note text:\n"
+            f"---\n"
+            f"{note_text}\n"
+            f"---\n\n"
+            f"Assess this requirement and respond using ONLY this exact format "
+            f"(no other text):\n"
+            f"STATUS: present|partial|missing\n"
+            f"SCORE: <float 0.0-1.0>\n"
+            f"EVIDENCE: <for 'present': direct quote or paraphrase; for 'partial': what was found AND what is missing; for 'missing': None found>\n"
+            f"NOTES: <brief explanation of your assessment>\n"
+            f"SUGGESTIONS: <if status is 'present' write None; otherwise write 1-3 specific actionable suggestions separated by ' | ' that reference the requirement above>"
+        )
+        return prompt
+
+    def _parse_element_response(
+        self,
+        response: str,
+        element: dict,
+    ) -> GapItem:
+        """
+        Parse structured LLM response into a GapItem.
+
+        Expected format:
+            STATUS: present|partial|missing
+            SCORE: 0.0–1.0
+            EVIDENCE: <verbatim excerpt or "None found">
+            NOTES: <optional reasoning>
+
+        Defensive parsing: handles missing fields, unexpected whitespace,
+        and LLM format drift without raising exceptions.
+        """
+        # Parse labelled fields — multi-line values are captured greedily
+        # until the next label or end of string.
+        label_pattern = re.compile(
+            r"^(STATUS|SCORE|EVIDENCE|NOTES|SUGGESTIONS)\s*:\s*(.+?)(?=\n(?:STATUS|SCORE|EVIDENCE|NOTES|SUGGESTIONS)\s*:|$)",
+            re.IGNORECASE | re.MULTILINE | re.DOTALL,
+        )
+        parsed: Dict[str, str] = {}
+        for match in label_pattern.finditer(response):
+            key = match.group(1).upper()
+            value = match.group(2).strip()
+            parsed[key] = value
+
+        # ── STATUS ────────────────────────────────────────────────────────────
+        raw_status = parsed.get("STATUS", "").lower()
+        if "present" in raw_status and "partial" not in raw_status:
+            status = "present"
+        elif "partial" in raw_status:
+            status = "partial"
+        else:
+            status = "missing"
+
+        # ── SCORE ─────────────────────────────────────────────────────────────
+        raw_score = parsed.get("SCORE", "")
+        score = self._extract_float_from_response(raw_score, default=0.0)
+        # Align score with status when LLM is inconsistent
+        if status == "missing" and score > 0.2:
+            score = 0.0
+        elif status == "present" and score < 0.5:
+            score = max(score, 0.7)
+
+        # ── EVIDENCE ──────────────────────────────────────────────────────────
+        # Missing elements → None (no evidence exists by definition).
+        # Present/partial → extracted text; empty string falls back to None.
+        evidence_raw = parsed.get("EVIDENCE", "").strip()
+        if status == "missing":
+            # Missing elements have no evidence by definition — always None
+            evidence: Optional[str] = None
+        elif evidence_raw.lower() in ("", "none", "none found"):
+            # Present/partial with no usable evidence text → empty string (not None)
+            evidence = ""
+        else:
+            evidence = evidence_raw
+
+        # ── NOTES ─────────────────────────────────────────────────────────────
+        notes: Optional[str] = None
+        if self.verbose:
+            notes = parsed.get("NOTES", "").strip() or None
+
+        # ── SUGGESTIONS ───────────────────────────────────────────────────────
+        # Only populated for gap elements (partial/missing).
+        # Present elements → empty list.
+        suggestions: List[str] = []
+        if status != "present":
+            raw_suggestions = parsed.get("SUGGESTIONS", "").strip()
+            if raw_suggestions and raw_suggestions.lower() not in ("none", "n/a", ""):
+                # Split on " | " (with spaces, as instructed in the prompt) to avoid
+                # accidentally splitting on a bare "|" within suggestion text
+                parts = raw_suggestions.split(" | ") if " | " in raw_suggestions else raw_suggestions.split("|")
+                suggestions = [
+                    s.strip()
+                    for s in parts
+                    if s.strip() and s.strip().lower() not in ("none", "n/a")
+                ][:3]  # cap at 3
+
+        return GapItem(
+            element_id=element["id"],
+            status=status,
+            score=score,
+            evidence=evidence,
+            severity=element["severity"],
+            required=element.get("required", True),
+            notes=notes,
+            suggestions=suggestions,
+        )
+
+    # ── Overall summary ────────────────────────────────────────────────────────
+
+    def _generate_summary(
+        self,
+        note_text: str,
+        framework: dict,
+        items: List[GapItem],
+    ) -> str:
+        """
+        Generate a concise human-readable summary of the evaluation results
+        via a single LLM call.
+        """
+        gaps = [
+            f"  - [{item.severity.upper()}] {item.element_id}: {item.status}"
+            for item in items
+            if item.status != "present"
+        ]
+        gaps_text = "\n".join(gaps) if gaps else "  (none)"
+
+        present_count = sum(1 for it in items if it.status == "present")
+        total = len(items)
+
+        prompt = (
+            f"System: You are a regulatory compliance analyst. Write a concise (3–5 sentence) "
+            f"plain-English summary of the following compliance note evaluation.\n\n"
+            f"Framework: {framework['name']} (v{framework['version']})\n"
+            f"Elements assessed: {total}\n"
+            f"Elements present: {present_count}/{total}\n"
+            f"Gaps identified:\n{gaps_text}\n\n"
+            f"Write a professional, factual summary suitable for an audit trail. "
+            f"Do not invent information beyond what is provided above."
+        )
+        try:
+            return self.llm.generate(prompt, max_tokens=300).strip()
+        except Exception as exc:
+            logger.warning("Summary generation failed (%s); using fallback.", exc)
+            return (
+                f"Evaluated {total} framework elements; "
+                f"{present_count} present, {len(gaps)} gap(s) identified."
+            )
+
+    # ── Statistics & scoring ───────────────────────────────────────────────────
+
+    def _compute_stats(self, items: List[GapItem]) -> GapReportStats:
+        """Compute summary statistics from a list of GapItems."""
+        total = len(items)
+        required = sum(1 for it in items if it.required)
+        present = sum(1 for it in items if it.status == "present")
+        partial = sum(1 for it in items if it.status == "partial")
+        missing = sum(1 for it in items if it.status == "missing")
+
+        def _gap_count(severity: str) -> int:
+            return sum(
+                1 for it in items
+                if it.severity == severity and it.status != "present"
+            )
+
+        required_missing = sum(
+            1 for it in items
+            if it.required and it.status in ("missing", "partial")
+        )
+
+        return GapReportStats(
+            total_elements=total,
+            required_elements=required,
+            present_count=present,
+            partial_count=partial,
+            missing_count=missing,
+            critical_gaps=_gap_count("critical"),
+            high_gaps=_gap_count("high"),
+            medium_gaps=_gap_count("medium"),
+            low_gaps=_gap_count("low"),
+            required_missing_count=required_missing,
+        )
+
+    def _compute_overall_score(self, items: List[GapItem]) -> float:
+        """
+        Weighted mean of element scores.
+        Required elements are weighted 2×, optional elements 1×.
+        """
+        if not items:
+            return 0.0
+
+        total_weight = 0.0
+        weighted_sum = 0.0
+        for item in items:
+            weight = 2.0 if item.required else 1.0
+            weighted_sum += item.score * weight
+            total_weight += weight
+
+        return round(weighted_sum / total_weight, 4) if total_weight > 0 else 0.0
+
+    def _determine_overall_rating(
+        self, items: List[GapItem], passed: bool
+    ) -> str:
+        """
+        Derive the human-readable overall compliance rating.
+
+        Rating logic (evaluated in priority order):
+          Non-Compliant      — failed AND at least one critical required element
+                               is missing or partial below threshold.
+          Requires Attention — failed but no critical blocker (high/medium gaps).
+          Minor Gaps         — passed but some elements are partial or optional
+                               elements are missing.
+          Compliant          — passed with every element fully present.
+        """
+        if not passed:
+            policy = self.pass_policy
+            has_critical_block = any(
+                it.severity == "critical"
+                and it.required
+                and (
+                    it.status == "missing"
+                    or (
+                        it.status == "partial"
+                        and it.score < policy.critical_partial_threshold
+                    )
+                )
+                for it in items
+            )
+            return "Non-Compliant" if has_critical_block else "Requires Attention"
+
+        has_gaps = any(it.status != "present" for it in items)
+        return "Minor Gaps" if has_gaps else "Compliant"
+
+    def _determine_pass(self, items: List[GapItem]) -> bool:
+        """Apply the PassPolicy to determine overall pass/fail."""
+        policy = self.pass_policy
+
+        for item in items:
+            if not item.required:
+                continue  # Optional elements never block a pass
+
+            if item.severity == "critical":
+                if policy.block_on_critical_missing and item.status == "missing":
+                    return False
+                if (
+                    policy.block_on_critical_partial
+                    and item.status == "partial"
+                    and item.score < policy.critical_partial_threshold
+                ):
+                    return False
+
+            elif item.severity == "high":
+                if policy.block_on_high_missing and item.status == "missing":
+                    return False
+
+        return True

--- a/packages/assert-review/assert_review/frameworks/fca_suitability_v1.yaml
+++ b/packages/assert-review/assert_review/frameworks/fca_suitability_v1.yaml
@@ -1,0 +1,121 @@
+# assert_llm_tools/frameworks/fca_suitability_v1.yaml
+
+framework_id: fca_suitability_v1
+name: FCA Suitability Note Framework
+version: 1.0.0
+regulator: FCA
+description: >
+  Defines the required elements for a suitability note produced under
+  COBS 9.2 (Suitability Reports) when providing personal recommendations
+  on retail investment products.
+effective_date: "2024-01-01"
+reference: "COBS 9.2 / PS13/1"
+
+elements:
+
+  - id: client_objectives
+    description: >
+      The note must document the client's investment objectives, including
+      time horizon, purpose of investment (e.g. retirement, income, growth),
+      and any specific goals or constraints stated by the client.
+    required: true
+    severity: critical
+    guidance: >
+      Look for explicit statements of what the client wants to achieve,
+      not just a product recommendation. Phrases like "client seeks",
+      "investment goal", "target date", "income requirement" are strong signals.
+
+  - id: risk_attitude
+    description: >
+      The note must record the client's attitude to risk (ATR) including
+      the outcome of any risk profiling exercise and the assigned risk
+      category (e.g. cautious, balanced, adventurous).
+    required: true
+    severity: critical
+    guidance: >
+      Look for a named risk category, a score from a risk questionnaire,
+      or explicit adviser assessment of risk tolerance. Absence of any
+      risk language is a clear gap.
+
+  - id: capacity_for_loss
+    description: >
+      The note must distinguish capacity for loss from attitude to risk,
+      documenting whether the client can financially sustain a loss of
+      capital without materially impacting their standard of living.
+    required: true
+    severity: critical
+    guidance: >
+      This is distinct from ATR. Look for references to disposable income,
+      emergency funds, essential expenditure, or a statement that losses
+      would/would not affect living standards.
+
+  - id: financial_situation
+    description: >
+      The note must summarise the client's financial position including
+      income, expenditure, assets, liabilities, and any existing investment
+      holdings relevant to the recommendation.
+    required: true
+    severity: high
+    guidance: >
+      Income and expenditure figures, pension values, savings balances,
+      mortgage details, or a statement of net worth all qualify. A generic
+      "financial situation reviewed" with no supporting detail is insufficient.
+
+  - id: knowledge_and_experience
+    description: >
+      The note must record the client's knowledge of and experience with
+      the relevant investment type, per MiFID II appropriateness principles
+      as applied under FCA rules.
+    required: true
+    severity: high
+    guidance: >
+      Look for assessment of prior investment experience (e.g. "client has
+      held ISAs for 10 years"), product familiarity, or educational background
+      in finance. Note any limitations or gaps the adviser identified.
+
+  - id: recommendation_rationale
+    description: >
+      The note must explain why the recommended product(s) are suitable for
+      this specific client, linking the recommendation explicitly back to the
+      client's objectives, risk profile, and financial situation.
+    required: true
+    severity: critical
+    guidance: >
+      Generic product descriptions do not count. The rationale must be
+      personalised: "this fund was selected because..." tied to the client's
+      documented profile. Look for causal language linking client attributes
+      to the recommendation.
+
+  - id: charges_and_costs
+    description: >
+      The note must disclose all relevant charges and costs associated with
+      the recommended product(s) and the advice service, including ongoing
+      and one-off fees.
+    required: true
+    severity: high
+    guidance: >
+      Look for percentage or monetary figures for product charges (OCF, AMC),
+      platform fees, and adviser fees. A statement that costs were "discussed
+      separately" may be acceptable if cross-referenced to a costs disclosure doc.
+
+  - id: alternatives_considered
+    description: >
+      The note should record that the adviser considered alternative products
+      or strategies, and explain why the recommendation was preferred.
+    required: false
+    severity: medium
+    guidance: >
+      May be implicit ("this product was selected over alternatives because...")
+      or explicit (a comparison table). Complete absence is a gap but not
+      automatically a breach.
+
+  - id: client_confirmation
+    description: >
+      The note should record that the client received, understood, and
+      acknowledged the recommendation, or that the recommendation was
+      discussed with the client.
+    required: false
+    severity: low
+    guidance: >
+      May be a signature reference, verbal confirmation note, or statement
+      that the report was issued and accepted. Absence is minor but noteworthy.

--- a/packages/assert-review/assert_review/loader.py
+++ b/packages/assert-review/assert_review/loader.py
@@ -5,9 +5,10 @@ load_framework() and _validate_framework() are intentionally kept separate
 from evaluate_note.py so they can be unit-tested and used independently
 (e.g. in a CLI validate-framework tool).
 """
-import yaml
 from pathlib import Path
 from typing import Any, Dict, Union
+
+import yaml
 
 # Built-in frameworks shipped with the package.
 # Resolved relative to this file so it works regardless of install location.

--- a/packages/assert-review/assert_review/loader.py
+++ b/packages/assert-review/assert_review/loader.py
@@ -1,0 +1,97 @@
+"""
+Framework loader for compliance note evaluation.
+
+load_framework() and _validate_framework() are intentionally kept separate
+from evaluate_note.py so they can be unit-tested and used independently
+(e.g. in a CLI validate-framework tool).
+"""
+import yaml
+from pathlib import Path
+from typing import Any, Dict, Union
+
+# Built-in frameworks shipped with the package.
+# Resolved relative to this file so it works regardless of install location.
+_BUILTIN_FRAMEWORKS_DIR = Path(__file__).parent / "frameworks"
+
+
+def load_framework(framework: Union[str, dict]) -> Dict[str, Any]:
+    """
+    Load and validate a regulatory framework definition.
+
+    Args:
+        framework: One of:
+            - A pre-loaded dict (returned as-is after validation).
+            - A path string to a YAML file (absolute or relative).
+            - A built-in framework_id string (e.g. "fca_suitability_v1"),
+              resolved against the library's bundled frameworks directory.
+
+    Returns:
+        Validated framework dict.
+
+    Raises:
+        FileNotFoundError: If no matching YAML file can be found.
+        ValueError: If the YAML is missing required top-level or element fields.
+    """
+    if isinstance(framework, dict):
+        _validate_framework(framework)
+        return framework
+
+    # Try as a literal file path first
+    path = Path(framework)
+    if not path.exists():
+        # Fall back to the built-in frameworks directory
+        path = _BUILTIN_FRAMEWORKS_DIR / f"{framework}.yaml"
+        if not path.exists():
+            raise FileNotFoundError(
+                f"Framework '{framework}' not found as a file path or as a built-in "
+                f"framework ID. Built-in frameworks live in: {_BUILTIN_FRAMEWORKS_DIR}"
+            )
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    _validate_framework(data)
+    return data
+
+
+def _validate_framework(framework: dict) -> None:
+    """
+    Raise ValueError if required framework fields are missing or invalid.
+
+    Validates:
+    - Top-level required keys: framework_id, name, version, regulator, elements
+    - Per-element required keys: id, description, required, severity
+    - Per-element severity values: critical | high | medium | low
+
+    Args:
+        framework: Framework dict to validate.
+
+    Raises:
+        ValueError: On any validation failure.
+    """
+    required_top_level = {"framework_id", "name", "version", "regulator", "elements"}
+    missing_top = required_top_level - set(framework.keys())
+    if missing_top:
+        raise ValueError(
+            f"Framework definition is missing required top-level fields: {missing_top}"
+        )
+
+    if not isinstance(framework["elements"], list) or len(framework["elements"]) == 0:
+        raise ValueError("Framework 'elements' must be a non-empty list.")
+
+    required_element_fields = {"id", "description", "required", "severity"}
+    valid_severities = {"critical", "high", "medium", "low"}
+
+    for i, element in enumerate(framework["elements"]):
+        missing_fields = required_element_fields - set(element.keys())
+        if missing_fields:
+            raise ValueError(
+                f"Framework element[{i}] (id={element.get('id', '<unknown>')}) "
+                f"is missing required fields: {missing_fields}"
+            )
+        if element["severity"] not in valid_severities:
+            raise ValueError(
+                f"Framework element[{i}] (id={element.get('id', '<unknown>')}) "
+                f"has invalid severity '{element['severity']}'. "
+                f"Must be one of: {valid_severities}"
+            )

--- a/packages/assert-review/assert_review/models.py
+++ b/packages/assert-review/assert_review/models.py
@@ -1,0 +1,147 @@
+"""
+Data models for compliance note evaluation.
+
+GapItem, GapReport, GapReportStats, and PassPolicy are importable directly
+from assert_review.models.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+
+# ── Type aliases ───────────────────────────────────────────────────────────────
+
+ElementStatus = Literal["present", "partial", "missing"]
+ElementSeverity = Literal["critical", "high", "medium", "low"]
+OverallRating = Literal["Compliant", "Minor Gaps", "Requires Attention", "Non-Compliant"]
+
+
+# ── Element-level result ───────────────────────────────────────────────────────
+
+@dataclass
+class GapItem:
+    """
+    Evaluation result for a single framework element.
+
+    Attributes:
+        element_id:   The element's id as defined in the framework YAML.
+        status:       Whether the element is present, partially present, or missing.
+        score:        Confidence/quality score for the element, 0.0–1.0.
+                      1.0 = fully present and well-documented.
+                      0.5 = partially addressed.
+                      0.0 = absent.
+        evidence:     Verbatim or paraphrased excerpt from the note that supports the
+                      status assessment. None when the element is missing entirely;
+                      for partial elements, captures what was found and what is absent.
+        severity:     Severity copied from the framework element definition —
+                      reflects the compliance impact if this element is absent/partial.
+        required:     Whether the element is required per the framework.
+        notes:        (optional) Free-text LLM commentary on the gap or quality.
+                      Populated only when verbose=True.
+        suggestions:  Actionable remediation suggestions (1–3 items) for gaps.
+                      Empty list when status is "present" — no action needed.
+    """
+
+    element_id: str
+    status: ElementStatus
+    score: float          # 0.0–1.0
+    evidence: Optional[str]   # None when element is missing
+    severity: ElementSeverity
+    required: bool
+    notes: Optional[str] = None
+    suggestions: List[str] = field(default_factory=list)
+
+
+# ── Top-level report ──────────────────────────────────────────────────────────
+
+@dataclass
+class GapReport:
+    """
+    Full evaluation report for a compliance note against a framework.
+
+    Attributes:
+        framework_id:       ID of the framework used for evaluation.
+        framework_version:  Version of the framework.
+        passed:             Overall pass/fail. True only if no required critical
+                            or high elements are missing/partial below threshold.
+        overall_score:      Weighted mean of element scores (required elements
+                            weighted 2×, optional elements 1×), 0.0–1.0.
+        overall_rating:     Human-readable compliance rating derived from pass/fail
+                            status and gap severity profile. One of:
+                            "Compliant"          — passed, no gaps at all.
+                            "Minor Gaps"         — passed, but some elements partial
+                                                   or optional elements missing.
+                            "Requires Attention" — failed due to high/medium gaps;
+                                                   no critical blockers.
+                            "Non-Compliant"      — failed due to critical required
+                                                   element gaps.
+        items:              List of GapItem, one per framework element.
+        summary:            Human-readable summary of the evaluation produced by the LLM.
+        stats:              Breakdown counts — see GapReportStats.
+        metadata:           Arbitrary key/value pairs (e.g. note_id, adviser_ref).
+    """
+
+    framework_id: str
+    framework_version: str
+    passed: bool
+    overall_score: float          # 0.0–1.0
+    overall_rating: OverallRating
+    items: List[GapItem]
+    summary: str
+    stats: "GapReportStats"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# ── Summary statistics ─────────────────────────────────────────────────────────
+
+@dataclass
+class GapReportStats:
+    """
+    Summary statistics for a GapReport.
+
+    Attributes:
+        total_elements:         Total number of elements in the framework.
+        required_elements:      Number of required elements.
+        present_count:          Elements with status == "present".
+        partial_count:          Elements with status == "partial".
+        missing_count:          Elements with status == "missing".
+        critical_gaps:          Missing/partial elements with severity == "critical".
+        high_gaps:              Missing/partial elements with severity == "high".
+        medium_gaps:            Missing/partial elements with severity == "medium".
+        low_gaps:               Missing/partial elements with severity == "low".
+        required_missing_count: Required elements that are missing or partial.
+    """
+
+    total_elements: int
+    required_elements: int
+    present_count: int
+    partial_count: int
+    missing_count: int
+    critical_gaps: int
+    high_gaps: int
+    medium_gaps: int
+    low_gaps: int
+    required_missing_count: int
+
+
+# ── Pass policy ────────────────────────────────────────────────────────────────
+
+@dataclass
+class PassPolicy:
+    """
+    Configures the pass/fail threshold for GapReport.passed.
+
+    Attributes:
+        block_on_critical_missing:  Fail if any critical required element is missing.
+        block_on_critical_partial:  Fail if any critical required element is partial
+                                    with score below critical_partial_threshold.
+        block_on_high_missing:      Fail if any high required element is missing.
+        critical_partial_threshold: Minimum score for a critical element to not
+                                    block on partial status. Default 0.5.
+    """
+
+    block_on_critical_missing: bool = True
+    block_on_critical_partial: bool = True
+    block_on_high_missing: bool = True
+    critical_partial_threshold: float = 0.5

--- a/packages/assert-review/assert_review/models.py
+++ b/packages/assert-review/assert_review/models.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional
 
-
 # ── Type aliases ───────────────────────────────────────────────────────────────
 
 ElementStatus = Literal["present", "partial", "missing"]

--- a/packages/assert-review/pyproject.toml
+++ b/packages/assert-review/pyproject.toml
@@ -6,10 +6,45 @@ build-backend = "setuptools.build_meta"
 name = "assert-review"
 version = "0.1.0"
 description = "LLM-based compliance note evaluation for financial services"
+readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
+authors = [
+    { name = "Charlie Douglas", email = "cdouglas@gmail.com" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Financial and Insurance Industry",
+    "Topic :: Office/Business :: Financial",
+]
 dependencies = [
     "assert-core>=0.1.0",
+    "pyyaml>=6.0",
 ]
 
-# Implementation coming in END-90
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-cov", "ruff>=0.4"]
+
+[project.scripts]
+assert-review = "assert_review.cli:main"
+
+[project.urls]
+"Homepage" = "https://github.com/charliedouglas/assert"
+"Bug Tracker" = "https://github.com/charliedouglas/assert/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["assert_review*"]
+
+[tool.setuptools.package-data]
+assert_review = ["frameworks/*.yaml"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]

--- a/packages/assert-review/tests/test_smoke.py
+++ b/packages/assert-review/tests/test_smoke.py
@@ -1,0 +1,554 @@
+"""
+test_smoke.py — assert-review package smoke tests (END-90)
+===========================================================
+
+Covers:
+  Unit tests  : loader, validator, parser, scorer, pass-policy, stats  (no real LLM)
+  Integration : full evaluate_note() pipeline with mocked LLM
+  API surface : public imports, re-exports
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from assert_review import GapItem, GapReport, GapReportStats, LLMConfig, PassPolicy, evaluate_note
+from assert_review.evaluate_note import NoteEvaluator
+from assert_review.loader import _validate_framework, load_framework
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+_MINIMAL_VALID_FRAMEWORK: dict = {
+    "framework_id": "test_fw",
+    "name": "Test Framework",
+    "version": "1.0.0",
+    "regulator": "TEST",
+    "elements": [
+        {
+            "id": "elem_a",
+            "description": "Element A description",
+            "required": True,
+            "severity": "critical",
+        }
+    ],
+}
+
+_ELEMENT_CRITICAL = {
+    "id": "elem_a",
+    "description": "Element A",
+    "required": True,
+    "severity": "critical",
+    "guidance": "Look for X.",
+}
+
+_ELEMENT_HIGH = {
+    "id": "elem_b",
+    "description": "Element B",
+    "required": True,
+    "severity": "high",
+}
+
+
+def _make_evaluator(verbose: bool = False, pass_policy: PassPolicy | None = None) -> NoteEvaluator:
+    """Create a NoteEvaluator with a fresh MagicMock as its LLM (no real API calls)."""
+    with patch("assert_core.llm.bedrock.BedrockLLM._initialize"):
+        ev = NoteEvaluator(verbose=verbose, pass_policy=pass_policy)
+    ev.llm = MagicMock(name="test_mock_llm")
+    return ev
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PUBLIC API SURFACE
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPublicAPI:
+
+    def test_evaluate_note_importable(self):
+        assert callable(evaluate_note)
+
+    def test_models_importable_from_top_level(self):
+        from assert_review import GapReport, GapItem, GapReportStats, PassPolicy
+        assert GapReport is not None
+        assert GapItem is not None
+        assert GapReportStats is not None
+        assert PassPolicy is not None
+
+    def test_llm_config_re_exported(self):
+        from assert_review import LLMConfig
+        assert LLMConfig is not None
+
+    def test_note_evaluator_importable(self):
+        from assert_review.evaluate_note import NoteEvaluator
+        assert NoteEvaluator is not None
+
+    def test_note_evaluator_extends_base_calculator(self):
+        from assert_core.metrics.base import BaseCalculator
+        assert issubclass(NoteEvaluator, BaseCalculator)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LOADER
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestLoadFramework:
+
+    def test_load_framework_with_valid_dict_returns_unchanged(self):
+        fw = load_framework(_MINIMAL_VALID_FRAMEWORK)
+        assert fw is _MINIMAL_VALID_FRAMEWORK
+        assert fw["framework_id"] == "test_fw"
+
+    def test_load_builtin_fca_suitability_v1(self):
+        fw = load_framework("fca_suitability_v1")
+        assert fw["framework_id"] == "fca_suitability_v1"
+        assert fw["regulator"] == "FCA"
+        assert len(fw["elements"]) == 9
+        ids = {e["id"] for e in fw["elements"]}
+        assert "client_objectives" in ids
+        assert "risk_attitude" in ids
+
+    def test_invalid_id_raises_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_framework("nonexistent_framework_xyz")
+
+    def test_invalid_file_path_raises_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_framework("/no/such/file.yaml")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FRAMEWORK VALIDATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestValidateFramework:
+
+    def test_missing_elements_field_raises(self):
+        bad = {"framework_id": "x", "name": "X", "version": "1.0", "regulator": "X"}
+        with pytest.raises(ValueError, match="elements"):
+            _validate_framework(bad)
+
+    def test_missing_framework_id_raises(self):
+        bad = {
+            "name": "X", "version": "1.0", "regulator": "X",
+            "elements": [{"id": "a", "description": "A", "required": True, "severity": "high"}],
+        }
+        with pytest.raises(ValueError, match="framework_id"):
+            _validate_framework(bad)
+
+    def test_empty_elements_list_raises(self):
+        with pytest.raises(ValueError):
+            _validate_framework({**_MINIMAL_VALID_FRAMEWORK, "elements": []})
+
+    def test_element_missing_severity_raises(self):
+        bad = {
+            **_MINIMAL_VALID_FRAMEWORK,
+            "elements": [{"id": "a", "description": "A", "required": True}],
+        }
+        with pytest.raises(ValueError, match="severity"):
+            _validate_framework(bad)
+
+    def test_invalid_severity_value_raises(self):
+        bad = {
+            **_MINIMAL_VALID_FRAMEWORK,
+            "elements": [{"id": "a", "description": "A", "required": True, "severity": "extreme"}],
+        }
+        with pytest.raises(ValueError, match="extreme"):
+            _validate_framework(bad)
+
+    def test_valid_framework_does_not_raise(self):
+        _validate_framework(_MINIMAL_VALID_FRAMEWORK)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RESPONSE PARSING
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestParseElementResponse:
+
+    def test_well_formed_present_response(self):
+        ev = _make_evaluator()
+        response = (
+            "STATUS: present\n"
+            "SCORE: 0.85\n"
+            "EVIDENCE: Client clearly states retirement goal in 10 years\n"
+            "NOTES: Fully documented"
+        )
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.element_id == "elem_a"
+        assert item.status == "present"
+        assert item.score == pytest.approx(0.85, abs=1e-3)
+        assert "retirement goal" in item.evidence
+        assert item.notes is None  # verbose=False
+
+    def test_verbose_includes_notes(self):
+        ev = _make_evaluator(verbose=True)
+        response = (
+            "STATUS: partial\nSCORE: 0.4\n"
+            "EVIDENCE: Some mention\nNOTES: Insufficient detail"
+        )
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.notes == "Insufficient detail"
+
+    def test_missing_score_no_crash(self):
+        ev = _make_evaluator()
+        response = "STATUS: missing\nEVIDENCE: None found\nNOTES: Absent"
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.status == "missing"
+        assert isinstance(item.score, float)
+
+    def test_missing_status_high_score_corrected(self):
+        ev = _make_evaluator()
+        response = "STATUS: missing\nSCORE: 0.9\nEVIDENCE: None found\nNOTES: Inconsistent"
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.status == "missing"
+        assert item.score == pytest.approx(0.0)
+
+    def test_evidence_none_on_missing_is_none(self):
+        ev = _make_evaluator()
+        response = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent"
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.evidence is None
+
+    def test_evidence_none_found_on_partial_is_empty_string(self):
+        ev = _make_evaluator()
+        response = "STATUS: partial\nSCORE: 0.4\nEVIDENCE: None found\nNOTES: Incomplete"
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.status == "partial"
+        assert item.evidence == ""
+        assert item.evidence is not None
+
+    def test_garbled_response_no_crash(self):
+        ev = _make_evaluator()
+        item = ev._parse_element_response("I cannot assess this.", _ELEMENT_CRITICAL)
+        assert item.status == "missing"
+        assert isinstance(item.score, float)
+
+    def test_empty_response_no_crash(self):
+        ev = _make_evaluator()
+        item = ev._parse_element_response("", _ELEMENT_CRITICAL)
+        assert item.status == "missing"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SCORING
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestComputeOverallScore:
+
+    def test_required_elements_weighted_twice(self):
+        ev = _make_evaluator()
+        items = [
+            GapItem("a", "present", 0.8, "evidence", "critical", required=True),
+            GapItem("b", "partial", 0.4, "evidence", "medium", required=False),
+        ]
+        score = ev._compute_overall_score(items)
+        assert score == pytest.approx(round(2.0 / 3.0, 4), abs=1e-4)
+
+    def test_empty_items_returns_zero(self):
+        ev = _make_evaluator()
+        assert ev._compute_overall_score([]) == 0.0
+
+    def test_single_required_item(self):
+        ev = _make_evaluator()
+        items = [GapItem("a", "present", 0.75, "", "high", required=True)]
+        assert ev._compute_overall_score(items) == pytest.approx(0.75, abs=1e-4)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PASS POLICY
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDeterminePass:
+
+    def test_critical_required_missing_fails(self):
+        ev = _make_evaluator()
+        items = [GapItem("a", "missing", 0.0, None, "critical", required=True)]
+        assert ev._determine_pass(items) is False
+
+    def test_high_required_missing_fails(self):
+        ev = _make_evaluator()
+        items = [GapItem("b", "missing", 0.0, None, "high", required=True)]
+        assert ev._determine_pass(items) is False
+
+    def test_optional_critical_missing_passes(self):
+        ev = _make_evaluator()
+        items = [GapItem("c", "missing", 0.0, None, "critical", required=False)]
+        assert ev._determine_pass(items) is True
+
+    def test_critical_partial_below_threshold_fails(self):
+        ev = _make_evaluator()
+        items = [GapItem("a", "partial", 0.3, "", "critical", required=True)]
+        assert ev._determine_pass(items) is False
+
+    def test_critical_partial_at_threshold_passes(self):
+        ev = _make_evaluator()
+        items = [GapItem("a", "partial", 0.5, "", "critical", required=True)]
+        assert ev._determine_pass(items) is True
+
+    def test_all_present_passes(self):
+        ev = _make_evaluator()
+        items = [
+            GapItem("a", "present", 0.9, "", "critical", required=True),
+            GapItem("b", "present", 0.8, "", "high", required=True),
+        ]
+        assert ev._determine_pass(items) is True
+
+    def test_medium_required_missing_does_not_block(self):
+        ev = _make_evaluator()
+        items = [GapItem("m", "missing", 0.0, None, "medium", required=True)]
+        assert ev._determine_pass(items) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PASS POLICY DEFAULTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPassPolicyDefaults:
+
+    def test_defaults(self):
+        p = PassPolicy()
+        assert p.block_on_critical_missing is True
+        assert p.block_on_critical_partial is True
+        assert p.block_on_high_missing is True
+        assert p.critical_partial_threshold == pytest.approx(0.5)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# STATS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestGapReportStats:
+
+    def _items(self):
+        return [
+            GapItem("a", "present", 0.9, "ev", "critical", required=True),
+            GapItem("b", "partial", 0.4, "ev", "high",     required=True),
+            GapItem("c", "missing", 0.0, None, "medium",   required=False),
+            GapItem("d", "missing", 0.0, None, "low",      required=True),
+            GapItem("e", "present", 0.8, "ev", "critical", required=False),
+        ]
+
+    def test_counts(self):
+        ev = _make_evaluator()
+        stats = ev._compute_stats(self._items())
+        assert stats.total_elements == 5
+        assert stats.required_elements == 3
+        assert stats.present_count == 2
+        assert stats.partial_count == 1
+        assert stats.missing_count == 2
+
+    def test_gap_counts_by_severity(self):
+        ev = _make_evaluator()
+        stats = ev._compute_stats(self._items())
+        assert stats.critical_gaps == 0   # both critical elements present
+        assert stats.high_gaps == 1       # b is partial
+        assert stats.medium_gaps == 1     # c is missing
+        assert stats.low_gaps == 1        # d is missing
+
+    def test_required_missing_count(self):
+        ev = _make_evaluator()
+        stats = ev._compute_stats(self._items())
+        assert stats.required_missing_count == 2   # b (partial) + d (missing)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OVERALL RATING
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestOverallRating:
+
+    def _item(self, status, severity, required=True, score=None):
+        s = 0.9 if status == "present" else (0.4 if status == "partial" else 0.0)
+        if score is not None:
+            s = score
+        ev_text = "evidence" if status != "missing" else None
+        return GapItem("x", status, s, ev_text, severity, required)
+
+    def test_compliant_all_present(self):
+        ev = _make_evaluator()
+        items = [self._item("present", "critical"), self._item("present", "high")]
+        assert ev._determine_overall_rating(items, passed=True) == "Compliant"
+
+    def test_minor_gaps_passed_with_partial(self):
+        ev = _make_evaluator()
+        items = [self._item("present", "critical"), self._item("partial", "medium")]
+        assert ev._determine_overall_rating(items, passed=True) == "Minor Gaps"
+
+    def test_non_compliant_critical_required_missing(self):
+        ev = _make_evaluator()
+        items = [self._item("missing", "critical", required=True)]
+        assert ev._determine_overall_rating(items, passed=False) == "Non-Compliant"
+
+    def test_requires_attention_failed_high_only(self):
+        ev = _make_evaluator(pass_policy=PassPolicy(block_on_critical_missing=True, block_on_high_missing=True, block_on_critical_partial=False))
+        items = [
+            self._item("present", "critical", required=True),
+            self._item("missing", "high", required=True),
+        ]
+        assert ev._determine_overall_rating(items, passed=False) == "Requires Attention"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SUGGESTIONS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSuggestions:
+
+    def test_suggestions_for_missing(self):
+        ev = _make_evaluator()
+        response = (
+            "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent\n"
+            "SUGGESTIONS: Document the client's retirement objective | Include target date | Note income requirements"
+        )
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert len(item.suggestions) == 3
+
+    def test_suggestions_empty_for_present(self):
+        ev = _make_evaluator()
+        response = (
+            "STATUS: present\nSCORE: 0.9\nEVIDENCE: Documented\nNOTES: Good\nSUGGESTIONS: None"
+        )
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert item.suggestions == []
+
+    def test_suggestions_capped_at_three(self):
+        ev = _make_evaluator()
+        response = (
+            "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent\n"
+            "SUGGESTIONS: S1 | S2 | S3 | S4"
+        )
+        item = ev._parse_element_response(response, _ELEMENT_CRITICAL)
+        assert len(item.suggestions) == 3
+
+    def test_prompt_contains_suggestions_field(self):
+        ev = _make_evaluator()
+        prompt = ev._build_element_prompt("Some note text", _ELEMENT_CRITICAL)
+        assert "SUGGESTIONS" in prompt
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# INTEGRATION — full pipeline with mocked LLM
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_FAKE_NOTE = (
+    "Client: Jane Smith. Objective: retirement in 15 years. "
+    "Risk profile: balanced (score 5/10). "
+    "Capacity for loss: client can absorb losses up to 20% without affecting living standards. "
+    "Financial situation: income £60k, savings £50k ISA, mortgage outstanding £200k. "
+    "Knowledge: client has held ISAs for 8 years, familiar with equity funds. "
+    "Recommendation: Global Equity Fund selected because it matches the client's balanced "
+    "risk profile and 15-year horizon. Charges: OCF 0.45%, adviser fee 0.5% p.a. "
+    "Alternatives considered: bond fund and cash ISA rejected as insufficient growth potential. "
+    "Client confirmed receipt of the suitability report."
+)
+
+_ELEMENT_RESPONSES = [
+    "STATUS: present\nSCORE: 0.9\nEVIDENCE: retirement in 15 years\nNOTES: Clear",
+    "STATUS: present\nSCORE: 0.85\nEVIDENCE: balanced (score 5/10)\nNOTES: Clear",
+    "STATUS: present\nSCORE: 0.8\nEVIDENCE: absorb losses up to 20%\nNOTES: Good",
+    "STATUS: present\nSCORE: 0.75\nEVIDENCE: income £60k, savings £50k\nNOTES: Present",
+    "STATUS: present\nSCORE: 0.7\nEVIDENCE: held ISAs for 8 years\nNOTES: Adequate",
+    "STATUS: present\nSCORE: 0.9\nEVIDENCE: matches balanced profile\nNOTES: Linked",
+    "STATUS: present\nSCORE: 0.8\nEVIDENCE: OCF 0.45% adviser 0.5%\nNOTES: Disclosed",
+    "STATUS: present\nSCORE: 0.6\nEVIDENCE: bond fund rejected\nNOTES: Mentioned",
+    "STATUS: present\nSCORE: 0.7\nEVIDENCE: client confirmed receipt\nNOTES: OK",
+]
+
+_SUMMARY_RESPONSE = (
+    "The note meets all 9 FCA suitability requirements. "
+    "Client objectives, risk, capacity for loss, financials, knowledge, "
+    "rationale, charges, alternatives, and confirmation are all documented."
+)
+
+
+class TestEvaluateNoteIntegration:
+
+    def _all_responses(self):
+        return _ELEMENT_RESPONSES + [_SUMMARY_RESPONSE]
+
+    def test_returns_gap_report(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert isinstance(report, GapReport)
+
+    def test_correct_framework_id(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert report.framework_id == "fca_suitability_v1"
+
+    def test_items_count_matches_elements(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert len(report.items) == 9
+
+    def test_all_present_passes(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert report.passed is True
+
+    def test_overall_score_in_range(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert 0.0 <= report.overall_score <= 1.0
+
+    def test_stats_total_matches_items(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert report.stats.total_elements == len(report.items)
+
+    def test_summary_is_non_empty_string(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert isinstance(report.summary, str) and report.summary.strip()
+
+    def test_overall_rating_compliant(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert report.overall_rating == "Compliant"
+
+    def test_critical_missing_fails_and_non_compliant(self):
+        ev = _make_evaluator()
+        responses = list(_ELEMENT_RESPONSES)
+        responses[0] = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent"
+        ev.llm.generate.side_effect = responses + [_SUMMARY_RESPONSE]
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        assert report.passed is False
+        assert report.overall_rating == "Non-Compliant"
+
+    def test_missing_element_has_null_evidence(self):
+        ev = _make_evaluator()
+        responses = list(_ELEMENT_RESPONSES)
+        responses[0] = "STATUS: missing\nSCORE: 0.0\nEVIDENCE: None found\nNOTES: Absent"
+        ev.llm.generate.side_effect = responses + [_SUMMARY_RESPONSE]
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1")
+        missing = next(it for it in report.items if it.status == "missing")
+        assert missing.evidence is None
+
+    def test_metadata_preserved(self):
+        ev = _make_evaluator()
+        ev.llm.generate.side_effect = self._all_responses()
+        meta = {"note_id": "N-001", "adviser": "Jane Doe"}
+        report = ev.evaluate(_FAKE_NOTE, "fca_suitability_v1", metadata=meta)
+        assert report.metadata["note_id"] == "N-001"
+
+    def test_top_level_evaluate_note_function(self):
+        """evaluate_note() top-level entry point works end-to-end."""
+        mock_llm = MagicMock()
+        mock_llm.generate.side_effect = self._all_responses()
+        with patch("assert_core.llm.bedrock.BedrockLLM._initialize"), \
+             patch("assert_core.llm.bedrock.BedrockLLM.generate", side_effect=self._all_responses()):
+            with patch("assert_core.metrics.base.BedrockLLM") as mock_cls:
+                mock_cls.return_value = mock_llm
+                report = evaluate_note(note_text=_FAKE_NOTE, framework="fca_suitability_v1")
+
+        assert isinstance(report, GapReport)
+        assert report.framework_id == "fca_suitability_v1"
+        assert len(report.items) == 9

--- a/test_docs.py
+++ b/test_docs.py
@@ -1,5 +1,5 @@
-from assert_llm_tools.core import evaluate_summary
-from assert_llm_tools.llm.config import LLMConfig
+from assert_eval import evaluate_summary
+from assert_eval import LLMConfig
 
 metrics = [
     "coverage",

--- a/test_evaluate_note_live.py
+++ b/test_evaluate_note_live.py
@@ -1,5 +1,5 @@
-from assert_llm_tools.metrics.note import evaluate_note
-from assert_llm_tools.llm.config import LLMConfig
+from assert_review import evaluate_note
+from assert_review import LLMConfig
 
 # Select one of Bedrock or OpenAI
 llm_config = LLMConfig(


### PR DESCRIPTION
## Summary

- Extracts compliance note evaluation from `assert_llm_tools` into a standalone `assert-review` PyPI package targeting financial services compliance teams
- Ports `NoteEvaluator`, `evaluate_note()`, all data models, and the FCA suitability framework from the legacy monolith; updates imports to use `assert-core`
- Adds `assert-review evaluate` / `assert-review batch` CLI entry points
- 57 unit + integration tests (all passing), CI on Python 3.9 + 3.11, PyPI publish workflow

## Files

| File | Description |
|---|---|
| `assert_review/models.py` | `GapItem`, `GapReport`, `GapReportStats`, `PassPolicy` |
| `assert_review/loader.py` | YAML framework loader; resolves built-in IDs from `assert_review/frameworks/` |
| `assert_review/evaluate_note.py` | `NoteEvaluator` (extends `assert_core.BaseCalculator`), `evaluate_note()` |
| `assert_review/cli.py` | `assert-review evaluate <note> --framework <id>` and `batch` subcommands |
| `assert_review/frameworks/fca_suitability_v1.yaml` | Bundled FCA COBS 9.2 framework (9 elements) |
| `tests/test_smoke.py` | 57 tests covering loader, validator, parser, scorer, pass-policy, stats, integration |
| `.github/workflows/ci-assert-review.yml` | CI on push/PR to `packages/assert-review/**` or `packages/assert-core/**` |
| `.github/workflows/publish-assert-review.yml` | PyPI publish on `assert-review-v*` tags |

## Public API

```python
from assert_review import evaluate_note, GapReport, GapItem, PassPolicy, LLMConfig

llm_config = LLMConfig(provider="bedrock", model_id="anthropic.claude-v2", region="us-east-1")
report = evaluate_note(note_text="...", framework="fca_suitability_v1", llm_config=llm_config)
```

## Test plan

- [ ] **Smoke tests (no credentials required)**
  ```bash
  pip install -e "packages/assert-core"
  pip install -e "packages/assert-review[dev]"
  pytest packages/assert-review/tests/ -v
  # Expected: 57 passed
  ```

- [ ] **CLI help**
  ```bash
  assert-review --help
  assert-review evaluate --help
  assert-review batch --help
  ```

- [ ] **CLI evaluate with a real note (requires AWS Bedrock creds)**
  ```bash
  echo "Client: Jane Smith. Objective: retirement in 15 years. Risk: balanced. \
  Capacity: can absorb 20% loss. Financials: income £60k. Knowledge: ISA holder 8 yrs. \
  Recommendation: Global Equity Fund, matches balanced profile. Charges: OCF 0.45%. \
  Alternatives: bond fund rejected. Client confirmed receipt." > /tmp/note.txt

  assert-review evaluate /tmp/note.txt --framework fca_suitability_v1
  # Expected: PASS / Compliant output

  assert-review evaluate /tmp/note.txt --framework fca_suitability_v1 --output json
  # Expected: JSON with passed=true, overall_rating="Compliant"
  ```

- [ ] **Custom framework YAML**
  ```bash
  assert-review evaluate /tmp/note.txt --framework assert_llm_tools/frameworks/fca_suitability_v1.yaml
  # Expected: same result using an explicit file path
  ```

- [ ] **GapReport JSON format matches existing assert_llm_tools output**
  ```python
  import json, dataclasses
  from assert_review import evaluate_note, LLMConfig
  # verify keys: framework_id, passed, overall_score, overall_rating, items, stats, metadata
  ```

- [ ] **CI passes** — check Actions tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)