### PR TITLE
feat(assert-review): improve LLM-as-judge quality with discriminating criteria and golden dataset

### DIFF
--- a/packages/assert-review/assert_review/frameworks/fca_suitability_v2.yaml
+++ b/packages/assert-review/assert_review/frameworks/fca_suitability_v2.yaml
@@ -65,6 +65,16 @@ elements:
       value. Note: if the note is attached to a CRM client record, the
       firm may consider structural identification sufficient — but the
       note should still be interpretable in isolation.
+    discriminating_criteria:
+      required_specificity:
+        - "States the client's full name (first and last name, not just a reference number)"
+        - "For joint clients: identifies both parties and notes who was present at the meeting"
+      pass_example: >
+        "Client: Margaret Thornton (ref MT-4421). Annual review. Attendees:
+        James Patel (adviser), Margaret Thornton (client)."
+      fail_example: >
+        "Meeting with client." or "Annual review conducted." — no name,
+        no identification of who was present.
 
   - id: client_objectives
     description: >
@@ -92,6 +102,19 @@ elements:
       "objectives reviewed, confirmed unchanged" is acceptable; silence
       is not. FCA treats unclear or undocumented objectives as automatic
       COBS 9.2 breaches.
+    discriminating_criteria:
+      required_specificity:
+        - "States a specific income target or capital goal in monetary terms — not just 'growth' or 'income'"
+        - "States a specific time horizon as an age, calendar date, or number of years — not just 'long term'"
+        - "For review meetings: explicitly confirms objectives were reviewed and are current, rather than being silent"
+      pass_example: >
+        "Primary goal: income supplement of £800–£1,000/month from age 62,
+        preserving residual capital for IHT gifting to two adult children.
+        Time horizon: 4 years to drawdown commencement."
+      fail_example: >
+        "Client's objective is long-term growth with some income." — no
+        monetary target, no specific time horizon, no link to client
+        circumstances.
 
   - id: risk_attitude
     description: >
@@ -119,6 +142,22 @@ elements:
       should not be interpreted as neutral risk appetite without further
       exploration. Absence of any risk language in an advice note is a
       clear gap cited in 100% of enforcement cases reviewed.
+    discriminating_criteria:
+      required_specificity:
+        - "Names the risk category assigned (e.g. 'Balanced', 'Growth', 'Cautious') — not just 'medium risk'"
+        - "Names or describes the profiling method used (e.g. 'firm questionnaire', 'FinaMetrica', 'adviser assessment')"
+        - "Includes a score, band, or indicator from the profiling exercise, not just a label"
+        - "Acknowledges at least one limitation of the tool or assessment process"
+      pass_example: >
+        "Margaret scored 34/60 on the firm's risk questionnaire (v3.1),
+        placing her in the Balanced category. Questionnaire limitations
+        discussed — hypothetical loss scenarios may not reflect real-world
+        behaviour; adviser explored actual loss comfort separately and
+        confirmed alignment."
+      fail_example: >
+        "Client is medium risk and comfortable with some market fluctuation."
+        — no named category, no score, no tool referenced, no limitations
+        acknowledged.
 
   - id: capacity_for_loss
     description: >
@@ -144,6 +183,22 @@ elements:
       to sustain potential loss, the firm must explain that higher returns
       cannot realistically be met. The single most impactful correction
       a firm can make is ensuring CFL is never conflated with ATR.
+    discriminating_criteria:
+      required_specificity:
+        - "Addresses CFL as a concept separate from ATR — uses distinct language or appears in a separate section"
+        - "References a concrete financial buffer: months of essential expenditure covered, liquid savings amount, or income surplus"
+        - "States explicitly whether investment losses would or would not affect the client's standard of living"
+      pass_example: >
+        "CFL assessed separately from ATR. Margaret holds £28,000 in liquid
+        savings (cash ISA and current account), covering 18 months of
+        essential expenditure. Investment losses up to 25% would not affect
+        her living standards. CFL assessed as moderate — does not constrain
+        the Balanced ATR."
+      fail_example: >
+        "Client understands investments can fall in value and is comfortable
+        with short-term volatility provided long-term goals are preserved."
+        — this describes ATR, not CFL; no financial buffer, no living
+        standards assessment.
 
   - id: recommendation_rationale
     description: >
@@ -176,6 +231,27 @@ elements:
       any loss of guarantees. A bare statement that "existing portfolio
       remains suitable" without supporting reasoning risks an "unclear"
       FCA rating.
+    discriminating_criteria:
+      required_specificity:
+        - "Names the specific product, fund, or strategy being recommended — not 'a suitable investment'"
+        - "Links the recommendation explicitly to the client's named time horizon (specific age, date, or number of years)"
+        - "References the client's specific risk score or named category from the profiling exercise"
+        - "Addresses capacity for loss as a documented constraint on the recommendation, distinct from ATR"
+        - "For product switches or replacement business: compares old vs new arrangement on cost, features, and any benefits surrendered"
+        - "For review meetings where no change is made: explains WHY existing arrangements remain suitable — not just states the conclusion"
+      pass_example: >
+        "Recommended switching the ISA to Provider X and commencing phased
+        pension drawdown from age 62. The ISA switch reduces the ongoing
+        charge from 0.85% to 0.45% (saving ~£640/year) with no change to
+        the fund or risk profile. Drawdown of £1,000/month from age 62 is
+        consistent with Margaret's income objective, her 4-year time horizon,
+        Balanced (34/60) ATR, and moderate CFL (constrained by £28k liquid
+        buffer). No guaranteed benefits are surrendered."
+      fail_example: >
+        "This recommendation is suitable for the client based on her risk
+        profile and investment objectives." — no named product, no time
+        horizon, no risk score, no CFL linkage, no client-specific
+        circumstances.
 
   # ──────────────────────────────────────────────
   # TIER 2: WARNING

--- a/packages/assert-review/assert_review/models.py
+++ b/packages/assert-review/assert_review/models.py
@@ -148,5 +148,5 @@ class PassPolicy:
     block_on_critical_missing: bool = True
     block_on_critical_partial: bool = True
     block_on_high_missing: bool = True
-    block_on_warning_missing: bool = True
+    block_on_warning_missing: bool = False
     critical_partial_threshold: float = 0.5

--- a/packages/assert-review/pyproject.toml
+++ b/packages/assert-review/pyproject.toml
@@ -41,6 +41,11 @@ include = ["assert_review*"]
 [tool.setuptools.package-data]
 assert_review = ["frameworks/*.yaml"]
 
+[tool.pytest.ini_options]
+markers = [
+    "golden: golden dataset calibration tests (require live LLM, set RUN_GOLDEN=1)",
+]
+
 [tool.ruff]
 line-length = 120
 target-version = "py39"

--- a/packages/assert-review/tests/golden/dataset.yaml
+++ b/packages/assert-review/tests/golden/dataset.yaml
@@ -1,0 +1,416 @@
+# Golden dataset for fca_suitability_v2 calibration.
+#
+# Synthetic but realistic notes covering failure modes cited in FCA enforcement.
+# Only the 2-4 most diagnostic elements are specified per note — this avoids
+# over-specifying and making the dataset brittle as guidance evolves.
+#
+# Status values: present | partial | missing
+# Use these to detect false positives (model marks "present" when expected "missing")
+# and false negatives (model marks "missing" when expected "present").
+
+version: "1.0"
+framework_id: fca_suitability_v2
+
+notes:
+
+  - id: gold_standard
+    description: >
+      Full annual review note with all elements present and client-specific.
+      Named product, named risk score, separate CFL with financial buffer,
+      quantified objectives, specific time horizon. Should pass comfortably.
+    expected:
+      overall_pass: true
+      elements:
+        recommendation_rationale: present
+        capacity_for_loss: present
+        client_objectives: present
+        risk_attitude: present
+        client_identification: present
+    note: |
+      Client Meeting Note
+      Client: Sarah Chen (ref SC-2241)
+      Date: 10 January 2026
+      Adviser: Daniel Wright
+      Meeting type: Annual review — in-person at adviser's office
+      Attendees: Daniel Wright (adviser), Sarah Chen (client)
+
+      Client profile:
+      Sarah is 54 years old, works as a GP (gross income £95,000 p.a.) and
+      holds an NHS Pension (projected income £28,000/year from age 60) and
+      a self-invested personal pension (SIPP, current value £186,000). No
+      outstanding mortgage. Monthly discretionary spend ~£1,800; essential
+      expenditure ~£2,200/month.
+
+      Objectives:
+      Primary objective: retire fully at 60, supplementing NHS pension with
+      SIPP drawdown of £2,000/month. Secondary objective: IHT planning for
+      estate (estimated £800k). Time horizon: 6 years to drawdown.
+
+      Risk attitude:
+      Sarah completed the firm's risk questionnaire (version 3.1) and scored
+      41/60, placing her in the Balanced-Growth category. She confirmed the
+      questionnaire outcome reflects her stated preferences. Limitations
+      acknowledged: questionnaire uses hypothetical loss scenarios; adviser
+      explored real-loss comfort separately and confirmed alignment.
+
+      Capacity for loss:
+      Assessed separately from ATR. Essential expenditure covered by income;
+      NHS pension would cover living costs in full from age 60. SIPP losses
+      of up to 25% would not affect living standards. CFL assessed as
+      moderate-high. CFL does not constrain the Balanced-Growth ATR.
+
+      Knowledge and experience:
+      Sarah has held the SIPP for 12 years, previously consolidated two
+      occupational pension schemes via an adviser. Familiar with fund-based
+      investing. No direct equity experience. Assessed as adequate for
+      recommended product type.
+
+      Existing arrangements:
+      SIPP reviewed. Current allocation: 60% global equity, 40% fixed income.
+      Performance: +6.2% over 12 months vs benchmark +5.8%. Portfolio risk
+      profile consistent with Balanced-Growth. No rebalancing required.
+
+      Recommendation:
+      No change to SIPP allocation. The 60/40 equity/bond split remains
+      appropriate for Sarah's 6-year horizon to drawdown, Balanced-Growth
+      (41/60) ATR, and moderate-high CFL. Income projection at current growth
+      assumptions (5% nominal): ~£2,100/month at age 60 — within target range.
+      No alternative strategy was identified as offering materially better
+      alignment with her specific circumstances.
+
+      Charges:
+      Platform fee 0.15% p.a. Adviser fee 0.50% p.a. Weighted fund OCF
+      0.38% p.a. Total 1.03% p.a. (~£1,916/year at current value). Costs
+      discussed; confirmed fair value relative to services received under
+      the annual review agreement.
+
+      Vulnerability:
+      No vulnerability indicators identified. Sarah engaged actively
+      throughout and demonstrated clear understanding of all points discussed.
+
+      Client understanding:
+      Explained that performance cannot be guaranteed and that drawdown
+      income is subject to sequence-of-returns risk. Sarah confirmed she
+      understood the projection caveats and that she is comfortable with
+      the plan. No changes to authorisations required.
+
+      Actions:
+      (1) Adviser to issue updated suitability report by 17 January 2026.
+      (2) Next annual review: January 2027.
+
+  - id: thin_passing
+    description: >
+      Minimal but technically sufficient documentation. Critical elements
+      are present but without depth — risk score given, CFL referenced with
+      a buffer, objectives have monetary target and time horizon, rationale
+      names the product and links to client's profile. Should pass overall
+      but some warning elements will be partial.
+    expected:
+      overall_pass: true
+      elements:
+        recommendation_rationale: present
+        capacity_for_loss: present
+        client_objectives: present
+        risk_attitude: present
+    note: |
+      Client: Robert Mills (ref RM-0091)
+      Date: 5 February 2026
+      Adviser: Kim Taylor
+      Meeting type: Annual review
+
+      Robert is 47, employed (income £52,000 p.a.). Holds ISA (£38,000)
+      and workplace pension (£91,000). No mortgage.
+
+      Objectives:
+      Capital growth targeting retirement at 60. Target pension pot of
+      £300,000 at age 60 to support drawdown. Time horizon: 13 years.
+
+      Risk:
+      Scored 38/60 on the firm's questionnaire — Balanced-Growth category.
+      No conflict between score and discussion. Tool limitations noted.
+
+      Capacity for loss:
+      Robert has £15,000 in savings covering 8 months essential expenditure.
+      Investment losses would not affect living standards. CFL moderate.
+
+      Recommendation:
+      Maintained existing Global Equity Fund ISA allocation. The fund suits
+      Robert's 13-year growth horizon and Balanced-Growth (38/60) ATR; losses
+      within his moderate CFL tolerance.
+
+      Charges:
+      OCF 0.22%, adviser 0.5%, platform 0.15%. Total 0.87% p.a.
+
+      Client:
+      Confirmed he had read the suitability report and understood the
+      recommendation, including that values can fall.
+
+  - id: generic_rationale
+    description: >
+      Note with a rationale section but no client-specific linkage — uses
+      "matches your risk profile and objectives" language. This is the
+      archetypal thin note FCA enforcement cites. recommendation_rationale
+      should be partial or missing. Other elements may vary.
+    expected:
+      overall_pass: false
+      elements:
+        recommendation_rationale: partial
+        client_objectives: present
+        risk_attitude: present
+    note: |
+      Client: Jennifer Park (ref JP-3301)
+      Date: 12 February 2026
+      Adviser: Tom Hughes
+      Meeting type: Initial advice
+
+      Jennifer is 52 and has received a redundancy payment of £75,000
+      she wishes to invest for retirement.
+
+      Objectives:
+      Long-term growth to supplement retirement income. Time horizon:
+      approximately 10 years.
+
+      Risk:
+      Jennifer is a balanced investor. She understands markets go up and
+      down. She has some experience of ISA investing.
+
+      Capacity for loss:
+      Jennifer has some savings and can afford to take some risk with
+      this sum.
+
+      Recommendation:
+      I recommended the Diversified Growth Fund. This is a well-regarded
+      fund that matches your risk profile and investment objectives. It
+      offers a good balance of risk and return. This recommendation is
+      suitable for Jennifer based on her profile and circumstances.
+
+      Charges:
+      OCF 0.65%, adviser 0.5%. Total 1.15% p.a.
+
+      Client signed the suitability letter and confirmed she was happy
+      to proceed.
+
+  - id: conflated_atr_cfl
+    description: >
+      ATR and CFL mentioned but not distinguished — merged into a single
+      "risk assessment" paragraph with no financial buffer, no living
+      standards statement. Both risk_attitude and capacity_for_loss should
+      be partial. The note should fail overall because CFL is a critical
+      required element.
+    expected:
+      overall_pass: false
+      elements:
+        risk_attitude: partial
+        capacity_for_loss: partial
+    note: |
+      Client: David Okafor (ref DO-7712)
+      Date: 18 February 2026
+      Adviser: Sophie Grant
+      Meeting type: Retirement planning — initial advice
+
+      David, 61, is retiring next year. Pension pot: £420,000.
+      State pension from age 67. Savings: £12,000.
+
+      Objectives:
+      Generate income of £1,500/month in retirement to supplement state
+      pension. Time horizon: 25+ years in drawdown.
+
+      Risk assessment:
+      David is cautious to moderate. He understands that investments can
+      fall in value and is comfortable with short-term fluctuations
+      provided long-term capital is preserved. He does not want to take
+      excessive risk given his age and proximity to retirement.
+
+      Recommendation:
+      I recommended a multi-asset cautious portfolio with a 30/70
+      equity/bond split. This suits David's cautious risk approach and
+      income objective. The projected yield at 3.5% gives approximately
+      £14,700/year, meeting the income target.
+
+      Charges:
+      OCF 0.55%, adviser 0.5%, platform 0.20%. Total 1.25% p.a.
+
+      Client confirmed understanding of the recommendation.
+
+  - id: minimal_understanding
+    description: >
+      Uses "client happy to proceed" as the entire record of client
+      understanding — the archetypal thin record FCA criticises post-
+      Consumer Duty. client_understanding should be partial. Other
+      critical elements are substantively present so overall should pass.
+    expected:
+      overall_pass: true
+      elements:
+        client_understanding: partial
+        recommendation_rationale: present
+        capacity_for_loss: present
+    note: |
+      Client: Frances Abbott (ref FA-0054)
+      Date: 20 January 2026
+      Adviser: Mark Singh
+      Meeting type: Annual review
+
+      Frances, 49, teacher (income £38,000). ISA (£54,000), pension
+      (£130,000). Mortgage: £85,000 outstanding (7 years remaining).
+
+      Objectives:
+      Retire at 58 with supplementary income of £1,200/month. Time
+      horizon: 9 years to drawdown.
+
+      Risk:
+      Scored 33/60 on firm questionnaire — Balanced category. Limitations
+      acknowledged; discussed actual loss scenarios separately.
+
+      Capacity for loss:
+      Mortgage payments manageable from income. £8,000 instant-access
+      savings. Investment losses of up to 20% would not affect essential
+      expenditure. CFL moderate, consistent with ATR.
+
+      Recommendation:
+      Increased equity allocation from 55% to 65% in both ISA and pension
+      to target higher growth over the 9-year horizon. Aligns with Balanced
+      (33/60) ATR and moderate CFL. Projected to produce the £1,200/month
+      income target at age 58 at 5.5% nominal growth.
+
+      Charges:
+      OCF 0.30%, adviser 0.5%, platform 0.12%. Total 0.92% p.a.
+
+      Client happy to proceed.
+
+  - id: missing_cfl
+    description: >
+      Complete and well-documented note in all other respects, but CFL
+      is genuinely absent — no mention of financial buffer, essential
+      expenditure, savings, or whether losses affect living standards.
+      capacity_for_loss should be missing; note should fail overall.
+    expected:
+      overall_pass: false
+      elements:
+        capacity_for_loss: missing
+        recommendation_rationale: present
+        client_objectives: present
+        risk_attitude: present
+    note: |
+      Client: Paul Merton (ref PM-9901)
+      Date: 3 February 2026
+      Adviser: Lisa Chen
+      Meeting type: Annual review
+
+      Paul, 55, self-employed (income ~£70,000 variable). ISA (£90,000),
+      SIPP (£240,000). No mortgage.
+
+      Objectives:
+      Target retirement at 63 with drawdown income of £2,500/month.
+      Time horizon: 8 years.
+
+      Risk:
+      Paul completed the firm's questionnaire and scored 44/60, placing
+      him in the Growth category. He confirmed the score reflects his
+      stated preferences. Questionnaire limitations noted and discussed.
+
+      Knowledge and experience:
+      Paul has invested via ISA for 15 years. Familiar with equity funds;
+      previously held a self-managed share portfolio.
+
+      Recommendation:
+      Increased equity allocation from 65% to 75% in both ISA and SIPP.
+      Aligns with Paul's Growth (44/60) ATR and 8-year horizon to
+      retirement at 63. Projected to produce £2,600/month drawdown income
+      at age 63 at 6% nominal growth — within target range.
+
+      Charges:
+      ISA OCF 0.28%, SIPP OCF 0.32%. Adviser 0.5%, platform 0.15%.
+      Total blended 0.97% p.a.
+
+      Client confirmed he understood the recommendation and authorised
+      the rebalancing instruction.
+
+  - id: replacement_business
+    description: >
+      ISA provider switch note. Cost saving is documented but no comparison
+      of features or guarantees surrendered. Under FG12/16, replacement
+      business requires documented comparison of old vs new on cost,
+      features, and any loss of benefits. alternatives_considered should
+      be partial (cost compared but features not addressed).
+    expected:
+      overall_pass: true
+      elements:
+        alternatives_considered: partial
+        recommendation_rationale: present
+        charges_and_costs: present
+        capacity_for_loss: present
+    note: |
+      Client: Helen Shaw (ref HS-1122)
+      Date: 15 January 2026
+      Adviser: James Cole
+      Meeting type: Product review — ISA switch
+
+      Helen, 44, marketing director (income £85,000). ISA with Provider A
+      (current value £67,000, OCF 0.95% p.a.). No mortgage. Savings:
+      £25,000 in instant-access account.
+
+      Objectives:
+      Long-term growth. Time horizon: 16 years to retirement at 60.
+
+      Risk:
+      Scored 46/60 — Growth category. Limitations acknowledged.
+
+      Capacity for loss:
+      £25,000 savings buffer covers 14 months essential expenditure.
+      Investment losses of up to 30% would not affect living standards.
+      CFL high, consistent with Growth ATR.
+
+      Recommendation:
+      Switch ISA from Provider A to Provider B. Provider B offers the
+      same fund range at OCF 0.42% — saving £357/year at current value.
+      The Growth portfolio allocation is unchanged: 80% global equity,
+      20% fixed income. Switch recommended on cost grounds. Helen confirmed
+      no specific features of Provider A she wished to retain.
+
+      Charges post-switch:
+      OCF 0.42%, adviser 0.5%, platform 0.18%. Total 1.10% p.a.
+      Previous total: 1.65% p.a. Switch cost: nil (in-specie transfer).
+
+      Client:
+      Confirmed understanding of the switch and cooling-off rights.
+      No concerns raised.
+
+  - id: bare_review
+    description: >
+      Annual review note that states existing arrangements were "reviewed"
+      and "remain suitable" with no supporting detail. Classic pattern
+      FCA cites in thematic reviews. existing_arrangements should be
+      missing or partial; recommendation_rationale should be partial.
+      Note should fail overall.
+    expected:
+      overall_pass: false
+      elements:
+        existing_arrangements: missing
+        recommendation_rationale: partial
+        client_objectives: partial
+    note: |
+      Client: Brian Foster (ref BF-4409)
+      Date: 28 January 2026
+      Adviser: Kate Morris
+      Meeting type: Annual review
+
+      Annual review meeting with Brian Foster, age 67. Retired.
+
+      Risk:
+      Balanced. Unchanged from previous review.
+
+      Objectives:
+      Reviewed. No changes noted.
+
+      Existing arrangements:
+      Portfolio reviewed. Remains suitable.
+
+      Recommendation:
+      No changes recommended at this time. Portfolio continues to meet
+      the client's requirements.
+
+      Charges:
+      As per existing service agreement. No changes.
+
+      Client:
+      Confirmed he was happy to continue as is.

--- a/packages/assert-review/tests/golden/test_golden_calibration.py
+++ b/packages/assert-review/tests/golden/test_golden_calibration.py
@@ -1,0 +1,267 @@
+"""
+test_golden_calibration.py — golden dataset calibration tests.
+
+Requires a live LLM. Skipped by default.
+
+Run with:
+    RUN_GOLDEN=1 pytest packages/assert-review/tests/golden/ -v -s
+    pytest packages/assert-review/tests/golden/ -m golden -v -s
+
+Configure the LLM via environment variables:
+    GOLDEN_LLM_PROVIDER   — "bedrock" (default) or "openai"
+    GOLDEN_MODEL_ID       — model ID (default: "us.amazon.nova-pro-v1:0")
+    GOLDEN_AWS_REGION     — AWS region (default: "us-east-1")
+    GOLDEN_OPENAI_API_KEY — required when GOLDEN_LLM_PROVIDER=openai
+"""
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import pytest
+import yaml
+
+from assert_review import LLMConfig, evaluate_note
+
+# ── Pytest marker ──────────────────────────────────────────────────────────────
+
+pytestmark = pytest.mark.golden
+
+# ── Skip guard ─────────────────────────────────────────────────────────────────
+
+_SHOULD_RUN = os.environ.get("RUN_GOLDEN", "0").strip() == "1"
+
+
+def _require_golden():
+    if not _SHOULD_RUN:
+        pytest.skip("Golden calibration skipped — set RUN_GOLDEN=1 to enable")
+
+
+# ── Dataset and LLM config ─────────────────────────────────────────────────────
+
+_DATASET_PATH = Path(__file__).parent / "dataset.yaml"
+
+_MAX_CRITICAL_FP_RATE = 0.25  # fail if any critical element exceeds this false-positive rate
+
+
+def _load_dataset() -> dict:
+    with open(_DATASET_PATH, "r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _get_llm_config() -> LLMConfig:
+    provider = os.environ.get("GOLDEN_LLM_PROVIDER", "bedrock")
+    return LLMConfig(
+        provider=provider,
+        model_id=os.environ.get("GOLDEN_MODEL_ID", "us.amazon.nova-pro-v1:0"),
+        region=os.environ.get("GOLDEN_AWS_REGION", "us-east-1"),
+        api_key=os.environ.get("GOLDEN_OPENAI_API_KEY"),
+    )
+
+
+# ── Status helpers ─────────────────────────────────────────────────────────────
+
+_STATUS_ORDER = {"present": 2, "partial": 1, "missing": 0}
+
+
+def _is_false_positive(actual: str, expected: str) -> bool:
+    """Model said 'present' when expected 'missing' — the dangerous error."""
+    return actual == "present" and expected == "missing"
+
+
+def _is_false_negative(actual: str, expected: str) -> bool:
+    """Model said 'missing' when expected 'present' — less dangerous, human catches it."""
+    return actual == "missing" and expected == "present"
+
+
+def _run_note(note_entry: dict, llm_config: LLMConfig) -> dict:
+    """Run a single dataset note through evaluate_note and return a result dict."""
+    dataset = _load_dataset()
+    report = evaluate_note(
+        note_text=note_entry["note"],
+        framework=dataset["framework_id"],
+        llm_config=llm_config,
+        verbose=False,
+    )
+    return {"id": note_entry["id"], "expected": note_entry["expected"], "report": report}
+
+
+def _assert_note_result(result: dict) -> None:
+    """
+    Assert the evaluation result against expected outcomes.
+
+    Only hard-asserts on:
+    - overall_pass (if specified)
+    - critical false positives (model says 'present' when expected 'missing' on a critical element)
+
+    Does not hard-assert on non-critical element statuses — those are measured
+    in the aggregate calibration report.
+    """
+    note_id = result["id"]
+    expected = result["expected"]
+    report = result["report"]
+
+    if "overall_pass" in expected:
+        assert report.passed == expected["overall_pass"], (
+            f"[{note_id}] overall_pass: expected={expected['overall_pass']}, "
+            f"got={report.passed} (rating={report.overall_rating}, "
+            f"score={report.overall_score:.2f})"
+        )
+
+    item_map = {it.element_id: it for it in report.items}
+    for elem_id, expected_status in expected.get("elements", {}).items():
+        assert elem_id in item_map, (
+            f"[{note_id}] Element '{elem_id}' not found in report items"
+        )
+        item = item_map[elem_id]
+        actual_status = item.status
+        if item.severity == "critical" and _is_false_positive(actual_status, expected_status):
+            pytest.fail(
+                f"[{note_id}] CRITICAL FALSE POSITIVE on '{elem_id}': "
+                f"expected={expected_status}, got={actual_status} "
+                f"(score={item.score:.2f}, evidence={str(item.evidence)[:80]!r})"
+            )
+
+
+# ── Per-note tests ─────────────────────────────────────────────────────────────
+
+class TestGoldenNotes:
+    """
+    One test method per golden note scenario.
+
+    Each test runs the note through evaluate_note() with a live LLM and checks:
+    - overall_pass matches expected
+    - no critical false positives (present when expected missing)
+    """
+
+    @pytest.fixture(autouse=True)
+    def skip_unless_golden(self):
+        _require_golden()
+
+    @pytest.fixture(scope="class")
+    def llm(self):
+        return _get_llm_config()
+
+    @pytest.fixture(scope="class")
+    def notes_by_id(self):
+        return {n["id"]: n for n in _load_dataset()["notes"]}
+
+    def test_gold_standard(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["gold_standard"], llm)
+        _assert_note_result(result)
+
+    def test_thin_passing(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["thin_passing"], llm)
+        _assert_note_result(result)
+
+    def test_generic_rationale(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["generic_rationale"], llm)
+        _assert_note_result(result)
+
+    def test_conflated_atr_cfl(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["conflated_atr_cfl"], llm)
+        _assert_note_result(result)
+
+    def test_minimal_understanding(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["minimal_understanding"], llm)
+        _assert_note_result(result)
+
+    def test_missing_cfl(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["missing_cfl"], llm)
+        _assert_note_result(result)
+
+    def test_replacement_business(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["replacement_business"], llm)
+        _assert_note_result(result)
+
+    def test_bare_review(self, llm, notes_by_id):
+        result = _run_note(notes_by_id["bare_review"], llm)
+        _assert_note_result(result)
+
+
+# ── Aggregate calibration report ──────────────────────────────────────────────
+
+class TestCalibrationReport:
+    """
+    Runs all golden notes and prints a per-element precision/recall table.
+
+    Fails if any critical element has a false-positive rate exceeding
+    _MAX_CRITICAL_FP_RATE (25%). This is the primary calibration gate.
+    """
+
+    @pytest.fixture(autouse=True)
+    def skip_unless_golden(self):
+        _require_golden()
+
+    def test_calibration_summary(self, capsys):
+        dataset = _load_dataset()
+        llm_config = _get_llm_config()
+
+        # Collect (element_id, severity, expected_status, actual_status) for all notes
+        records: List[Tuple[str, str, str, str]] = []
+
+        for note_entry in dataset["notes"]:
+            report = evaluate_note(
+                note_text=note_entry["note"],
+                framework=dataset["framework_id"],
+                llm_config=llm_config,
+                verbose=False,
+            )
+            item_map = {it.element_id: it for it in report.items}
+            for elem_id, expected_status in note_entry["expected"].get("elements", {}).items():
+                if elem_id in item_map:
+                    item = item_map[elem_id]
+                    records.append((elem_id, item.severity, expected_status, item.status))
+
+        # Aggregate per element
+        element_stats: Dict[str, Dict] = defaultdict(
+            lambda: {"fp": 0, "fn": 0, "correct": 0, "total": 0, "severity": "unknown"}
+        )
+        for elem_id, severity, expected, actual in records:
+            s = element_stats[elem_id]
+            s["total"] += 1
+            s["severity"] = severity
+            if _is_false_positive(actual, expected):
+                s["fp"] += 1
+            elif _is_false_negative(actual, expected):
+                s["fn"] += 1
+            else:
+                s["correct"] += 1
+
+        # Print calibration table
+        with capsys.disabled():
+            print("\n" + "=" * 72)
+            print("GOLDEN DATASET CALIBRATION REPORT")
+            print(f"Framework: {dataset['framework_id']}  |  Notes: {len(dataset['notes'])}")
+            print("=" * 72)
+            print(f"{'Element':<38} {'Sev':<10} {'FP Rate':<10} {'FN Rate':<10} {'N'}")
+            print("-" * 72)
+            for elem_id in sorted(element_stats):
+                s = element_stats[elem_id]
+                n = s["total"]
+                fp_rate = s["fp"] / n if n > 0 else 0.0
+                fn_rate = s["fn"] / n if n > 0 else 0.0
+                flag = (
+                    "  *** EXCEEDS THRESHOLD"
+                    if fp_rate > _MAX_CRITICAL_FP_RATE and s["severity"] == "critical"
+                    else ""
+                )
+                print(
+                    f"{elem_id:<38} {s['severity']:<10} {fp_rate:<10.1%} {fn_rate:<10.1%} {n}{flag}"
+                )
+            print("=" * 72)
+
+        # Assert: no critical element exceeds the false-positive rate threshold
+        violations = [
+            (eid, s["fp"] / s["total"])
+            for eid, s in element_stats.items()
+            if s["severity"] == "critical"
+            and s["total"] > 0
+            and (s["fp"] / s["total"]) > _MAX_CRITICAL_FP_RATE
+        ]
+        assert not violations, (
+            f"Critical element false-positive rate exceeds {_MAX_CRITICAL_FP_RATE:.0%}:\n"
+            + "\n".join(f"  {eid}: {rate:.1%}" for eid, rate in violations)
+        )

--- a/test_evaluate_note_live.py
+++ b/test_evaluate_note_live.py
@@ -15,6 +15,8 @@ Client Meeting Note — Margaret Thornton
 Date: 14 February 2026
 Adviser: James Patel
 Meeting type: Annual review
+Attendees: James Patel (adviser), Margaret Thornton (client)
+Channel: In-person at adviser’s office
 
 Client profile:
 Margaret is 58 years old and retired from teaching in 2023. She holds an existing


### PR DESCRIPTION
## Summary

- **Discriminating criteria** — adds `discriminating_criteria` blocks to the 5 critical `fca_suitability_v2` elements (`client_identification`, `client_objectives`, `risk_attitude`, `capacity_for_loss`, `recommendation_rationale`). Each block carries a `required_specificity` checklist plus concrete `pass_example` / `fail_example` to anchor LLM evaluation against behavioural markers. This addresses the false-positive problem where generic notes (e.g. "matches your risk profile and objectives") would incorrectly pass the `recommendation_rationale` check.
- **Golden calibration dataset** — 8 synthetic notes covering the enforcement-relevant failure modes (gold standard, thin passing, generic rationale, conflated ATR/CFL, minimal understanding, missing CFL, replacement business, bare review). Test harness at `tests/golden/` is skipped by default (`RUN_GOLDEN=1` to enable). Hard-asserts on overall pass/fail and critical false positives; `TestCalibrationReport` prints a per-element FP/FN table and enforces a ≤25% critical FP threshold.
- **PassPolicy fix** — `block_on_warning_missing` default changed from `True` → `False`. Warning elements contribute to score and rating but no longer gate pass/fail. Only critical element gaps block a pass, which aligns with the severity semantics ("critical = probable regulatory breach", "warning = material risk but not a hard fail").

## Test plan

- [ ] `pytest packages/assert-review/tests/ -v` — 64 unit tests pass, golden tests skipped
- [ ] `RUN_GOLDEN=1 pytest packages/assert-review/tests/golden/ -v -s` — all 8 per-note tests pass, calibration report shows 0% FP/FN on critical elements
- [ ] `python test_evaluate_note_live.py` — live smoke test against Bedrock still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)