### PR TITLE
chore: remove unused logging from assert-eval and assert-review

### DIFF
--- a/packages/assert-eval/assert_eval/evaluate_summary.py
+++ b/packages/assert-eval/assert_eval/evaluate_summary.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Dict, List, Optional
 
 from assert_core.llm.config import LLMConfig
@@ -7,8 +6,6 @@ from .metrics.coverage import calculate_coverage
 from .metrics.factual_alignment import calculate_factual_alignment
 from .metrics.factual_consistency import calculate_factual_consistency
 from .metrics.topic_preservation import calculate_topic_preservation
-
-logger = logging.getLogger(__name__)
 
 AVAILABLE_SUMMARY_METRICS = [
     "coverage",

--- a/packages/assert-review/assert_review/evaluate_note.py
+++ b/packages/assert-review/assert_review/evaluate_note.py
@@ -7,7 +7,6 @@ into a structured GapReport.
 """
 from __future__ import annotations
 
-import logging
 import re
 from typing import Any, Dict, List, Optional, Union
 
@@ -16,9 +15,6 @@ from assert_core.metrics.base import BaseCalculator
 
 from .loader import load_framework
 from .models import GapItem, GapReport, GapReportStats, PassPolicy
-
-logger = logging.getLogger(__name__)
-
 
 # ── Public entry point ─────────────────────────────────────────────────────────
 
@@ -124,7 +120,6 @@ class NoteEvaluator(BaseCalculator):
         # 2. Evaluate each element independently
         items: List[GapItem] = []
         for element in fw["elements"]:
-            logger.debug("Evaluating element: %s", element["id"])
             item = self._evaluate_element(note_text, element)
             items.append(item)
 
@@ -356,8 +351,7 @@ class NoteEvaluator(BaseCalculator):
         )
         try:
             return self.llm.generate(prompt, max_tokens=300).strip()
-        except Exception as exc:
-            logger.warning("Summary generation failed (%s); using fallback.", exc)
+        except Exception:
             return (
                 f"Evaluated {total} framework elements; "
                 f"{present_count} present, {len(gaps)} gap(s) identified."


### PR DESCRIPTION
## Summary

- Removed unused `import logging` and `logger` instance from `assert-eval/evaluate_summary.py` (logger was never called)
- Removed `import logging`, `logger` instance, `logger.debug(...)` trace, and `logger.warning(...)` fallback from `assert-review/evaluate_note.py`

## Test plan

- [ ] Confirm `assert-eval` and `assert-review` tests pass
- [ ] Verify no references to `logging` remain in either package

🤖 Generated with [Claude Code](https://claude.com/claude-code)